### PR TITLE
Setting: eslint no-use-before-define 설정 off

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,46 +1,43 @@
 {
-    "root": true,
-    "env": {
-        "browser": true,
-        "es2021": true,
-        "node": true,
-        "jest": true
-    },
-    "settings": {
-        "import/resolver": {
-            "typescript": {}
-        }
-    },
-    "extends": [
-        "airbnb",
-        "airbnb-typescript",
-        "airbnb/hooks",
-        "eslint:recommended",
-        "plugin:react/recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:@typescript-eslint/recommended-requiring-type-checking",
-        "prettier"
-    ],
-    "overrides": [
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaFeatures": {
-            "jsx": true
-        },
-        "ecmaVersion": "latest",
-        "sourceType": "module",
-        "project": "./tsconfig.json"
-    },
-    "ignorePatterns": ["node_modules/"],
-    "plugins": [
-        "react",
-        "@typescript-eslint"
-    ],
-    "rules": {
-        "no-var": "error",
-        "eqeqeq": "warn",
-        "react/jsx-pascal-case": "error",
-        "react/self-closing-comp": "warn"
+  "root": true,
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true,
+    "jest": true
+  },
+  "settings": {
+    "import/resolver": {
+      "typescript": {}
     }
+  },
+  "extends": [
+    "airbnb",
+    "airbnb-typescript",
+    "airbnb/hooks",
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "prettier"
+  ],
+  "overrides": [],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": "latest",
+    "sourceType": "module",
+    "project": "./tsconfig.json"
+  },
+  "ignorePatterns": ["node_modules/"],
+  "plugins": ["react", "@typescript-eslint"],
+  "rules": {
+    "no-var": "error",
+    "eqeqeq": "warn",
+    "react/jsx-pascal-case": "error",
+    "react/self-closing-comp": "warn",
+    "@typescript-eslint/no-use-before-define": "off"
+  }
 }


### PR DESCRIPTION
- 스타일드 컴포넌트를 컴포넌트 리턴문 아래에 선언해 가독성을 올리기 위해
eslint no-use-before-define 설정 off로 변경했습니다.