### PR TITLE
Design: global-style에 div, input, button border-radius 설정추가

### DIFF
--- a/src/styles/global-styles.tsx
+++ b/src/styles/global-styles.tsx
@@ -13,9 +13,10 @@ const GlobalStyle = createGlobalStyle`
     font-family:'Maven Pro', sans-serif;
     //글씨체 추후 확정되면 수정
   }
-  input, button {
+  div, input, button {
     background-color: transparent;
     border: none;
+    border-radius: 30px;
     outline: none;
   }
   h1, h2, h3, h4, h5, h6{


### PR DESCRIPTION
와이어프레임 중 거의 모든 div, input, button의 border-radius가 30px인 것을 알았습니다.
일일히 설정하지 않고 global-style에서 설정한 후, border-radius가 30px이 아닌 것에만 따로 설정을 하는 것을 어떨까 하여 건의합니다!

@gandy818 @caffesale 의견 부탁드립니다~!