### PR TITLE
Setting: package.json eslint 대상 경로 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "eslint ./src/**/*.{js,jsx,ts,tsx}",
-    "lint:fix": "eslint --fix ./src/**/*.{js,jsx,ts,tsx}",
-    "lint-staged": "eslint --cache --fix ./src/**/*.{js,jsx,ts,tsx}",
+    "lint": "eslint ./src/**/*.{ts,tsx}",
+    "lint:fix": "eslint --fix ./src/**/*.{ts,tsx}",
+    "lint-staged": "eslint --cache --fix ./src/**/*.{ts,tsx}",
     "prepare": "husky install"
   },
   "browserslist": {


### PR DESCRIPTION

저희 프로젝트에 js, jsx파일이 없는데 검사를 실행하려고 하니 오류가 나서 eslint 검사의 대상 파일 확장자 중 js, jsx를 삭제했습니다.