### PR TITLE
Feat: api instance 생성, gitingnore에 .env파일 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/utils/apiInstance.tsx
+++ b/src/utils/apiInstance.tsx
@@ -1,0 +1,20 @@
+import axios from "axios";
+
+axios.defaults.withCredentials = true;
+
+const apiInstance = axios.create({
+  baseURL: process.env.REACT_APP_BASE_URL,
+});
+
+apiInstance.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem("access_token");
+    const newConfig = config;
+    if (newConfig.headers)
+      newConfig.headers.Authorization = token ? `Bearer ${token}` : null;
+    return newConfig;
+  },
+  (err) => Promise.reject(err)
+);
+
+export default apiInstance;


### PR DESCRIPTION
api instance 생성해서 pr 날립니다! 조금 더 구체적인 설명은 아래 comment에 달았습니다.
궁금하거나 수정할만한 부분 있으면 피드백 부탁드립니다!
dev와 main에 오류 해결되고 두분 다 확인해주시면 머지하겠습니다.



1. api instance 생성: src > utils 폴더에 생성했습니다.
2. 요청 보내기 전 헤더에 토큰 첨부: 일일이 토큰을 넣어서 요청할 필요가 없습니다.
3. instance의 baseURL은 보안을 위해 .env 파일에서 관리:  깃허브에 올라가지 않기 때문에 각자 추가해야합니다.


api instance 사용예시도 같이 첨부해드립니다:)
```
//로그인 api (POST)
const clickSignUpBtn = async () => {
    const reqBody = {~~~~요청 시 body에 첨부해서 보내는 데이터};
    interface Response {~~~~요청 후 응답으로 받는 데이터의 타입}
    try {
      const res: AxiosResponse<Response> =
        await apiInstance.post("/signup", reqBody);     // api 인스턴스 사용 , 첫번째 인자로 "/내가 보낼 url",
                                                         두번째 인자로 request body(보내야 한다면)
      ~~~~
      요청 성공 시 처리할 로직
      ~~~~
    } catch (err) {
      ~~~
      요청 실패 시 처리할 로직
      ~~~
    }
  };
```