### PR TITLE
Setting: jsx-a11y/no-static-element-interactions 무효화

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,6 +53,7 @@
         "labelAttributes": ["htmlFor"]
       }
     ],
+    "jsx-a11y/no-static-element-interactions": "off",
     "@typescript-eslint/no-misused-promises": "off"
   }
 }


### PR DESCRIPTION
이벤트 버블링을 사용하는데 방해가 되어 문서에 명시된대로 off 했습니다.