### PR TITLE
Feat: 페이지네이션 컴포넌트 재사용하도록 수정

### DIFF
--- a/src/components/PageNoBar.tsx
+++ b/src/components/PageNoBar.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import styled from "styled-components";
-import arrowRightIcon from "../../assets/icons/arrowRight.svg";
-import arrowLeftIcon from "../../assets/icons/arrowLeft.svg";
-import arrowRightDoubleIcon from "../../assets/icons/arrowRightDouble.svg";
-import arrowLeftDoubleIcon from "../../assets/icons/arrowLeftDouble.svg";
-import { PagesState } from "../../types/exhbList";
+import arrowRight from "../assets/icons/arrowRight.svg";
+import arrowLeft from "../assets/icons/arrowLeft.svg";
+import arrowRightDouble from "../assets/icons/arrowRightDouble.svg";
+import arrowLeftDouble from "../assets/icons/arrowLeftDouble.svg";
+import { PagesState } from "../types/exhbList";
 
 const PageNoBar = (props: PageNoBarType) => {
   const { pages, setPages, totalPage } = props;
@@ -60,10 +60,10 @@ const PageNoBar = (props: PageNoBarType) => {
   return (
     <PageNoContanier className={totalPage ? "" : "none"}>
       <button type="button" name="doubleMinus" onClick={handlePageArrow}>
-        <img alt="double left icon" src={arrowLeftDoubleIcon} />
+        <img alt="double left icon" src={arrowLeftDouble} />
       </button>
       <button type="button" name="minus" onClick={handlePageArrow}>
-        <img alt="left icon" src={arrowLeftIcon} />
+        <img alt="left icon" src={arrowLeft} />
       </button>
       {getPageNoArr(totalPage).map((pageNo) => {
         const { selected, started } = pages;
@@ -82,10 +82,10 @@ const PageNoBar = (props: PageNoBarType) => {
         return null;
       })}
       <button type="button" name="plus" onClick={handlePageArrow}>
-        <img alt="right icon" src={arrowRightIcon} />
+        <img alt="right icon" src={arrowRight} />
       </button>
       <button type="button" name="doublePlus" onClick={handlePageArrow}>
-        <img alt="double right icon" src={arrowRightDoubleIcon} />
+        <img alt="double right icon" src={arrowRightDouble} />
       </button>
     </PageNoContanier>
   );

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -5,89 +5,117 @@ import arrowLeft from "../assets/icons/arrowLeft.svg";
 import arrowRightDouble from "../assets/icons/arrowRightDouble.svg";
 import arrowLeftDouble from "../assets/icons/arrowLeftDouble.svg";
 import { PagesState } from "../types/exhbList";
+import { theme } from "../styles/theme";
 
 // 페이지네이션 컴포넌트_박예선_23.01.21
 const Pagination = (props: PaginationType) => {
   const { pages, setPages, totalPage } = props;
   const { started, selected } = pages;
 
-  // 페이지 넘버 클릭 함수_박예선_23.01.16
+  // 페이지 넘버 클릭 함수_박예선_23.01.21
   const clickPageNo = (e: React.MouseEvent<HTMLButtonElement>) => {
     const newSelected = Number(e.currentTarget.innerHTML);
-    if (newSelected !== pages.selected) {
-      setPages({ ...pages, selected: newSelected });
-    }
+    setPages({ ...pages, selected: newSelected });
   };
 
-  // 좌우 페이지 방향버튼 클릭 함수_박예선_23.01.16
-  const handlePageArrow = (e: React.MouseEvent<HTMLButtonElement>) => {
-    const { name } = e.currentTarget;
-    if (!totalPage) return;
-    if (name === "leftDouble") {
-      if (started !== 1) {
-        setPages({ ...pages, started: started - 5, selected: started - 1 });
-      }
-      if (started === 1) {
-        setPages({ ...pages, selected: 1 });
-      }
+  // 전전 화살표 클릭 함수_박예선_23.01.21
+  const clickArrowLeftDouble = () => {
+    if (started === 1) {
+      setPages({ ...pages, selected: 1 });
+      return;
     }
-    if (name === "left") {
-      if (selected === 1) return;
-      if (started === selected) {
-        setPages({ ...pages, started: started - 5, selected: selected - 1 });
-      }
-      if (selected - started >= 1)
-        setPages({ ...pages, selected: selected - 1 });
+    if (started === selected)
+      setPages({ started: started - 5, selected: started - 5 });
+    if (started !== selected) setPages({ ...pages, selected: started });
+  };
+
+  // 이전 화살표 클릭 함수_박예선_23.01.21
+  const clickArrowLeft = () => {
+    if (started === selected) {
+      setPages({ started: started - 5, selected: selected - 1 });
     }
-    if (name === "right") {
-      if (totalPage === selected) return;
-      if (selected - started < 4) {
-        setPages({ ...pages, selected: selected + 1 });
-      }
-      if (started + 4 === selected) {
-        setPages({ ...pages, started: started + 5, selected: started + 5 });
-      }
-    }
-    if (name === "rightDouble") {
+    if (started !== selected) setPages({ ...pages, selected: selected - 1 });
+  };
+
+  // 다다음 화살표 클릭 함수_박예선_23.01.21
+  const clickArrowRightDouble = () => {
+    if (selected !== started + 4) {
+      setPages({ ...pages, selected: started + 4 });
       if (started >= totalPage - 4) {
         setPages({ ...pages, selected: totalPage });
       }
-      if (started < totalPage - 4) {
-        setPages({ ...pages, started: started + 5, selected: started + 5 });
-      }
+      return;
+    }
+    if (started + 4 >= totalPage - 5) {
+      setPages({ started: started + 5, selected: totalPage });
+      return;
+    }
+    if (selected === started + 4) {
+      setPages({ started: started + 5, selected: selected + 5 });
+    }
+  };
+
+  // 다음 화살표 클릭 함수_박예선_23.01.21
+  const clickArrowRight = () => {
+    if (selected < started + 4) {
+      setPages({ ...pages, selected: selected + 1 });
+    }
+    if (selected === started + 4) {
+      setPages({ started: started + 5, selected: started + 5 });
     }
   };
 
   return (
-    <PageNoContanier className={totalPage ? "" : "none"}>
-      <button type="button" name="leftDouble" onClick={handlePageArrow}>
-        <img alt="double left icon" src={arrowLeftDouble} />
-      </button>
-      <button type="button" name="left" onClick={handlePageArrow}>
-        <img alt="left icon" src={arrowLeft} />
-      </button>
+    <PaginationContainer className={`flex ${totalPage ? "" : "none"}`}>
+      <div className="flex">
+        <ArrowBtn
+          type="button"
+          onClick={clickArrowLeftDouble}
+          disabled={selected === 1}
+        >
+          <img alt="double left icon" src={arrowLeftDouble} />
+        </ArrowBtn>
+        <ArrowBtn
+          type="button"
+          onClick={clickArrowLeft}
+          disabled={selected === 1}
+        >
+          <img alt="left icon" src={arrowLeft} />
+        </ArrowBtn>
+      </div>
       {getPageNoArr(totalPage).map((pageNo) => {
         if (pageNo >= started && pageNo <= started + 4) {
           return (
-            <button
-              onClick={clickPageNo}
-              className={pageNo === selected ? "selected" : ""}
-              key={pageNo}
+            <PageNoBtn
               type="button"
+              key={pageNo}
+              className={pageNo === selected ? "selected" : ""}
+              onClick={clickPageNo}
+              disabled={pageNo === selected}
             >
               {pageNo}
-            </button>
+            </PageNoBtn>
           );
         }
         return null;
       })}
-      <button type="button" name="right" onClick={handlePageArrow}>
-        <img alt="right icon" src={arrowRight} />
-      </button>
-      <button type="button" name="rightDouble" onClick={handlePageArrow}>
-        <img alt="double right icon" src={arrowRightDouble} />
-      </button>
-    </PageNoContanier>
+      <div className="flex">
+        <ArrowBtn
+          type="button"
+          onClick={clickArrowRight}
+          disabled={selected === totalPage}
+        >
+          <img alt="right icon" src={arrowRight} />
+        </ArrowBtn>
+        <ArrowBtn
+          type="button"
+          onClick={clickArrowRightDouble}
+          disabled={selected === totalPage}
+        >
+          <img alt="double right icon" src={arrowRightDouble} />
+        </ArrowBtn>
+      </div>
+    </PaginationContainer>
   );
 };
 
@@ -108,8 +136,7 @@ function getPageNoArr(totalPage: number) {
   return newArr;
 }
 
-const PageNoContanier = styled.div`
-  display: flex;
+const PaginationContainer = styled.div`
   justify-content: space-between;
   width: 326px;
   height: 30px;
@@ -118,11 +145,32 @@ const PageNoContanier = styled.div`
     width: 30px;
     height: 30px;
     padding: 0;
+    font-size: 14px;
     font-weight: 500;
     cursor: pointer;
-    &.selected {
-      background-color: #6750a4;
-      color: ${(props) => props.theme.colors.white100};
+    :hover {
+      background-color: ${theme.colors.greys40};
+    }
+    &:focus-visible {
+      border: 1px solid ${theme.colors.primry80};
+      border-radius: 0;
+    }
+  }
+`;
+
+const ArrowBtn = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const PageNoBtn = styled.button`
+  color: ${theme.colors.greys60};
+  &.selected {
+    background-color: ${theme.colors.primry70};
+    color: ${theme.colors.white100};
+    :hover {
+      background-color: ${theme.colors.primry70};
     }
   }
 `;

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -4,7 +4,6 @@ import arrowRight from "../assets/icons/arrowRight.svg";
 import arrowLeft from "../assets/icons/arrowLeft.svg";
 import arrowRightDouble from "../assets/icons/arrowRightDouble.svg";
 import arrowLeftDouble from "../assets/icons/arrowLeftDouble.svg";
-import { PagesState } from "../types/exhbList";
 import { theme } from "../styles/theme";
 
 // 페이지네이션 컴포넌트_박예선_23.01.21
@@ -120,6 +119,11 @@ const Pagination = (props: PaginationType) => {
 };
 
 export default Pagination;
+
+export interface PagesState {
+  started: number;
+  selected: number;
+}
 
 interface PaginationType {
   pages: PagesState;

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -23,17 +23,20 @@ const Pagination = (props: PaginationType) => {
       setPages({ ...pages, selected: 1 });
       return;
     }
-    if (started === selected)
+    if (started === selected) {
       setPages({ started: started - 5, selected: started - 5 });
-    if (started !== selected) setPages({ ...pages, selected: started });
+      return;
+    }
+    setPages({ ...pages, selected: started });
   };
 
   // 이전 화살표 클릭 함수_박예선_23.01.21
   const clickArrowLeft = () => {
     if (started === selected) {
       setPages({ started: started - 5, selected: selected - 1 });
+      return;
     }
-    if (started !== selected) setPages({ ...pages, selected: selected - 1 });
+    setPages({ ...pages, selected: selected - 1 });
   };
 
   // 다다음 화살표 클릭 함수_박예선_23.01.21
@@ -58,6 +61,7 @@ const Pagination = (props: PaginationType) => {
   const clickArrowRight = () => {
     if (selected < started + 4) {
       setPages({ ...pages, selected: selected + 1 });
+      return;
     }
     if (selected === started + 4) {
       setPages({ started: started + 5, selected: started + 5 });

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -6,8 +6,10 @@ import arrowRightDouble from "../assets/icons/arrowRightDouble.svg";
 import arrowLeftDouble from "../assets/icons/arrowLeftDouble.svg";
 import { PagesState } from "../types/exhbList";
 
-const PageNoBar = (props: PageNoBarType) => {
+// 페이지네이션 컴포넌트_박예선_23.01.21
+const Pagination = (props: PaginationType) => {
   const { pages, setPages, totalPage } = props;
+  const { started, selected } = pages;
 
   // 페이지 넘버 클릭 함수_박예선_23.01.16
   const clickPageNo = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -19,54 +21,52 @@ const PageNoBar = (props: PageNoBarType) => {
 
   // 좌우 페이지 방향버튼 클릭 함수_박예선_23.01.16
   const handlePageArrow = (e: React.MouseEvent<HTMLButtonElement>) => {
-    const { started, selected } = pages;
     const { name } = e.currentTarget;
     if (!totalPage) return;
-    if (name === "doubleMinus") {
+    if (name === "leftDouble") {
       if (started !== 1) {
-        setPages({ started: started - 5, selected: started - 1 });
+        setPages({ ...pages, started: started - 5, selected: started - 1 });
       }
       if (started === 1) {
         setPages({ ...pages, selected: 1 });
       }
     }
-    if (name === "minus") {
+    if (name === "left") {
       if (selected === 1) return;
       if (started === selected) {
-        setPages({ started: started - 5, selected: selected - 1 });
+        setPages({ ...pages, started: started - 5, selected: selected - 1 });
       }
       if (selected - started >= 1)
         setPages({ ...pages, selected: selected - 1 });
     }
-    if (name === "plus") {
+    if (name === "right") {
       if (totalPage === selected) return;
       if (selected - started < 4) {
         setPages({ ...pages, selected: selected + 1 });
       }
       if (started + 4 === selected) {
-        setPages({ started: started + 5, selected: started + 5 });
+        setPages({ ...pages, started: started + 5, selected: started + 5 });
       }
     }
-    if (name === "doublePlus") {
+    if (name === "rightDouble") {
       if (started >= totalPage - 4) {
         setPages({ ...pages, selected: totalPage });
       }
       if (started < totalPage - 4) {
-        setPages({ started: started + 5, selected: started + 5 });
+        setPages({ ...pages, started: started + 5, selected: started + 5 });
       }
     }
   };
 
   return (
     <PageNoContanier className={totalPage ? "" : "none"}>
-      <button type="button" name="doubleMinus" onClick={handlePageArrow}>
+      <button type="button" name="leftDouble" onClick={handlePageArrow}>
         <img alt="double left icon" src={arrowLeftDouble} />
       </button>
-      <button type="button" name="minus" onClick={handlePageArrow}>
+      <button type="button" name="left" onClick={handlePageArrow}>
         <img alt="left icon" src={arrowLeft} />
       </button>
       {getPageNoArr(totalPage).map((pageNo) => {
-        const { selected, started } = pages;
         if (pageNo >= started && pageNo <= started + 4) {
           return (
             <button
@@ -81,19 +81,19 @@ const PageNoBar = (props: PageNoBarType) => {
         }
         return null;
       })}
-      <button type="button" name="plus" onClick={handlePageArrow}>
+      <button type="button" name="right" onClick={handlePageArrow}>
         <img alt="right icon" src={arrowRight} />
       </button>
-      <button type="button" name="doublePlus" onClick={handlePageArrow}>
+      <button type="button" name="rightDouble" onClick={handlePageArrow}>
         <img alt="double right icon" src={arrowRightDouble} />
       </button>
     </PageNoContanier>
   );
 };
 
-export default PageNoBar;
+export default Pagination;
 
-interface PageNoBarType {
+interface PaginationType {
   pages: PagesState;
   setPages: React.Dispatch<React.SetStateAction<PagesState>>;
   totalPage: number;

--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
-import { ExhbTypeFilters, FilterType, PagesState } from "../../types/exhbList";
+import { ExhbTypeFilters, FilterType } from "../../types/exhbList";
+import { PagesState } from "../Pagination";
 
 const Filters = (props: FiltersType) => {
   const {

--- a/src/pages/ExhibitionList.tsx
+++ b/src/pages/ExhibitionList.tsx
@@ -4,10 +4,10 @@ import styled from "styled-components";
 import { ExhbTypeFilters, Exhibition, FilterType } from "../types/exhbList";
 import exhbListApi, { ExhbListRes } from "../apis/getExhbList";
 import ExhibitionCard from "../components/exhibitionList/ExhibitionCard";
-import PageNoBar from "../components/PageNoBar";
+import Pagination from "../components/Pagination";
 import Filters, { StatusType } from "../components/exhibitionList/Filters";
 
-// 전시회 목록 페이지 컴포넌트_박예선_23.01.18
+// 전시회 목록 페이지 컴포넌트_박예선_23.01.21
 const ExhibitionList = () => {
   const [exhbList, setExhbList] = useState<Exhibition[]>([]);
   const [totalPage, setTotalPage] = useState<number>(0);
@@ -63,7 +63,7 @@ const ExhibitionList = () => {
           <ExhibitionCard key={exhb.id} exhbData={exhb} />
         ))}
       </CardListContainer>
-      <PageNoBar pages={pages} setPages={setPages} totalPage={totalPage} />
+      <Pagination pages={pages} setPages={setPages} totalPage={totalPage} />
     </ExhibitionListContainer>
   );
 };

--- a/src/pages/ExhibitionList.tsx
+++ b/src/pages/ExhibitionList.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { ExhbTypeFilters, Exhibition, FilterType } from "../types/exhbList";
 import exhbListApi, { ExhbListRes } from "../apis/getExhbList";
 import ExhibitionCard from "../components/exhibitionList/ExhibitionCard";
-import PageNoBar from "../components/exhibitionList/PageNoBar";
+import PageNoBar from "../components/PageNoBar";
 import Filters, { StatusType } from "../components/exhibitionList/Filters";
 
 // 전시회 목록 페이지 컴포넌트_박예선_23.01.18

--- a/src/types/exhbList.d.ts
+++ b/src/types/exhbList.d.ts
@@ -9,14 +9,9 @@ export interface Exhibition {
   viewCount: number;
 }
 
-export type FilterType = "전체" | "영상" | "특별" | "기획" | "상설" | "소장품";
-
-export interface PagesState {
-  started: number;
-  selected: number;
-}
-
 export interface ExhbTypeFilters {
   selected: FilterType;
   applied: FilterType;
 }
+
+export type FilterType = "전체" | "영상" | "특별" | "기획" | "상설" | "소장품";


### PR DESCRIPTION
1. 페이지네이션 컴포넌트 완성했습니다. pages, setPages, totalPage 세가지 props를 받습니다.
  -1. pages: 시작페이지, 선택된 페이지의 정보를 담고있는 state입니다. { started: number, selected: number }
  -2. setPages: pages의 set함수입니다.
  -3. totalPage: api를 통해 얻는 총 페이지 수입니다. 부모 컴포넌트에서 state로 상태관리되고있는 값입니다. 
                          각자 작성하신 코드에 맞게 적용하시면 됩니다
                         제 코드 중 ExhibitionList.tsx(전시회 목록) 참고하시면 도움될 것 같습니다!

2. 컴포넌트 파일내에서 사용하는 아이콘 변수명 컨벤션대로 변경했습니다(arrowLeftIcon -> arrowLeft 등)
3. 화살표 클릭함수 분리: 전전, 이전, 다음, 다다음 화살표 클릭 이벤트를 핸들링하는 함수가 하나였는데, 보기 복잡해서 각각의 버튼을 핸들링하는 함수로 리팩토링했습니다.
4. PageNoBar에서 Pagination으로 파일명, 컴포넌트명 변경이 이루어져서 ExhibitionList컴포넌트에도 변경사항 적용했습니다.
5. 페이지 넘버 버튼, 좌우 화살표 버튼 active, hover, focus, default 디자인 다 적용되어있습니다.