### PR TITLE
Design: checkOn, checkOff svg 색상 수정

### DIFF
--- a/src/assets/icons/checkOff.svg
+++ b/src/assets/icons/checkOff.svg
@@ -1,4 +1,6 @@
+<!-- 필요한 props -->
+<!-- stroke: 테두리 색 -->
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="12" cy="12" r="10" stroke="#9C9C9C" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M7.5 12L10.5 15L16.5 9" stroke="#9C9C9C" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="12" cy="12" r="10" stroke="current" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.5 12L10.5 15L16.5 9" stroke="current" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/assets/icons/checkOn.svg
+++ b/src/assets/icons/checkOn.svg
@@ -1,4 +1,6 @@
+<!-- 필요한 props -->
+<!-- fill: 원 안에 채워지는 색 -->
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="12" cy="12" r="10" fill="#9C9C9C"/>
+<circle cx="12" cy="12" r="10" fill="current"/>
 <path d="M7.5 12L10.5 15L16.5 9" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/components/atom/CheckLabel.tsx
+++ b/src/components/atom/CheckLabel.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { theme } from "../../styles/theme";
+import { ReactComponent as CheckOn } from "../../assets/icons/checkOn.svg";
+import { ReactComponent as CheckOff } from "../../assets/icons/checkOff.svg";
+
+interface CheckLabelType {
+  label: string;
+  onClick: () => void; // 체크박스를 클릭했을 때 실행될 함수
+}
+
+// 체크박스 + 라벨 컴포넌트_박예선_23.01.23
+const CheckLabel = ({ label, onClick }: CheckLabelType) => {
+  const [isChecked, setIsChecked] = useState(false);
+  const [isCheckOffHover, setIsCheckOffHover] = useState(false);
+
+  return (
+    <CheckLabelContainer
+      type="button"
+      onClick={() => {
+        setIsChecked(!isChecked);
+        onClick();
+      }}
+      onMouseOver={() => setIsCheckOffHover(true)}
+      onMouseOut={() => setIsCheckOffHover(false)}
+    >
+      {isChecked && <CheckOn fill={theme.colors.primry70} />}
+      {!isChecked && (
+        <CheckOff
+          stroke={isCheckOffHover ? theme.colors.greys80 : theme.colors.greys60}
+        />
+      )}
+      <label className={`label ${isChecked ? "checked" : ""}`}>{label}</label>
+    </CheckLabelContainer>
+  );
+};
+export default CheckLabel;
+
+const CheckLabelContainer = styled.button`
+  display: flex;
+  padding: 0;
+  align-items: center;
+  cursor: pointer;
+  :hover {
+    label {
+      color: ${theme.colors.greys80};
+    }
+  }
+  label {
+    margin-left: 4px;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 20px;
+    color: ${theme.colors.greys60};
+    cursor: pointer;
+    &.checked {
+      color: ${theme.colors.primry70};
+    }
+  }
+  :focus-visible {
+    border: 1px solid ${theme.colors.primry80};
+    border-radius: 0;
+  }
+`;


### PR DESCRIPTION
제가 컴포넌트만 완성하고 checkOn이랑 checkOff svg를 수정을 안해놔서
현재 메인에 CheckLabel 컴포넌트는 색이 반영이 안되네요 😥
수정사항 반영해서 pr합니다

이 pr이 머지되고 나면
svg에 props로 넘겨줘야 하는 색은 current로 되어있어서 그냥 img로 사용하신 분들은
색이 안나오게 되는게 정상입니다!
(이 아이콘은 전부 체크박스+라벨로 구성되어 있는 걸로 알아서
기존의 체크박스+라벨을 구성하신 분이 있다면
이 컴포넌트 사용하시면 됩니다!)

<!-- 필요한 props -->
<!-- stroke: 테두리 색 -->
이런식으로 svg파일에 필요한 props 주석처리 해뒀습니다!