### PR TITLE
Fix: 로그아웃 시 로컬스토리지 정보 삭제, 로그인 시 로컬스토리지 저장되는 정보 수정, 로그아웃버튼에 로그아웃 적용 #129

### DIFF
--- a/src/apis/logOut.tsx
+++ b/src/apis/logOut.tsx
@@ -1,8 +1,9 @@
-import axios, { AxiosResponse } from "axios";
+import { AxiosResponse } from "axios";
 import { useNavigate } from "react-router-dom";
 import apiInstance from "../utils/apiInstance";
+import isApiError from "../utils/isApiError";
 
-// 로그아웃 커스텀훅_박예선_2023.01.19
+// 로그아웃 커스텀훅_박예선_2023.01.25
 // 단순 로그아웃 시 호출: useLogOut();
 // refresh_token 만료 로그아웃 시 호출: useLogOut("refresh_token 만료");
 const useLogOut = (type?: "refreshToken 만료") => {
@@ -10,28 +11,26 @@ const useLogOut = (type?: "refreshToken 만료") => {
 
   const logOut = async () => {
     try {
-      const res: AxiosResponse<LogOutRes> =
-        //   await apiInstance.post(
-        //   "/api/me/logout"
-        // );
-        await axios.get("/data/logOut.json"); // 테스트용 목데이터
-      const { resultCode, errorMsg } = res.data;
+      const res: AxiosResponse<LogOutRes> = await apiInstance.post(
+        "/api/me/logout"
+      );
+      const { resultCode } = res.data;
       if (resultCode === 200) {
         localStorage.removeItem("accessToken");
         localStorage.removeItem("refreshToken");
+        localStorage.removeItem("memberId");
+        localStorage.removeItem("email");
+        localStorage.removeItem("nickname");
+        localStorage.removeItem("memberImage");
+        localStorage.removeItem("authority");
         if (!type) {
           alert("로그아웃되었습니다.");
           navigate("/");
           return;
         }
       }
-      if (errorMsg === "Forbidden") {
-        alert("유효하지 않은 요청입니다. 다시 시도해주십시오.");
-      }
     } catch (err) {
-      alert(
-        "죄송합니다.\n통신에 오류가 있어 로그아웃에 실패하였습니다. 다시 시도해주십시오."
-      );
+      isApiError(err);
     }
   };
   return logOut;

--- a/src/apis/member.tsx
+++ b/src/apis/member.tsx
@@ -2,12 +2,10 @@ import axios, { AxiosResponse } from "axios";
 import apiInstance from "../utils/apiInstance";
 import { errorAlert } from "../utils/isApiError";
 
-// 내정보 조회/수정(회원, 관리자 공통) api_박예선_23.01.20
+// 내정보 조회/수정(회원, 관리자 공통) api_박예선_23.01.25
 export const myInfoApi = async (type: "get" | "put") => {
   if (type === "get") {
-    const getRes: AxiosResponse<MyInfoRes> =
-      // await apiInstance.get("/api/me");
-      await axios.get("/data/member.json"); // 테스트용 목데이터
+    const getRes: AxiosResponse<MyInfoRes> = await apiInstance.get("/api/me");
     return getRes;
   }
   if (type === "put") {
@@ -20,13 +18,13 @@ export const myInfoApi = async (type: "get" | "put") => {
 };
 
 export interface MyInfoRes {
-  userId: number;
+  memberId: number;
   email: string;
   nickname: string;
   gender: "W" | "M";
   birth: string; // YYYY-MM-DD
   level: "level1" | "level2" | "level3" | "level4";
-  userImage: string | "";
+  memberImage: string | "";
   authority: "ROLE_USER" | "ROLE_ADMIN";
 }
 

--- a/src/components/HamburgerMenu.tsx
+++ b/src/components/HamburgerMenu.tsx
@@ -1,41 +1,47 @@
 import React from "react";
 import styled from "styled-components";
+import useLogOut from "../apis/logOut";
 import ProfileImg from "../assets/icons/profileImg.svg";
 
-const HamburgerMenu = () => (
-  <MenuContainer>
-    <MenuWrapper>
-      <Subtitle>계정</Subtitle>
-      <MypageArea href="/">
-        <ProfileWrapper>
-          <img src={ProfileImg} alt="profile-img" style={{ width: "40px" }} />
-        </ProfileWrapper>
-        <div>
-          <Nickname>Nickname</Nickname>
-          <Email className="email">email11@email.com</Email>
-        </div>
-      </MypageArea>
-      <LogoutButton type="button">로그아웃</LogoutButton>
-    </MenuWrapper>
-    <MenuWrapper>
-      <Subtitle>메뉴</Subtitle>
-      <ul>
-        <List as="a" href="/">
-          전시회
-        </List>
-        <List as="a" href="/">
-          전시회 리뷰
-        </List>
-        <List as="a" href="/">
-          메이트 찾기
-        </List>
-        {/* <List as="a" href="/">
+const HamburgerMenu = () => {
+  const logOut = useLogOut();
+  return (
+    <MenuContainer>
+      <MenuWrapper>
+        <Subtitle>계정</Subtitle>
+        <MypageArea href="/">
+          <ProfileWrapper>
+            <img src={ProfileImg} alt="profile-img" style={{ width: "40px" }} />
+          </ProfileWrapper>
+          <div>
+            <Nickname>Nickname</Nickname>
+            <Email className="email">email11@email.com</Email>
+          </div>
+        </MypageArea>
+        <LogoutButton type="button" onClick={logOut}>
+          로그아웃
+        </LogoutButton>
+      </MenuWrapper>
+      <MenuWrapper>
+        <Subtitle>메뉴</Subtitle>
+        <ul>
+          <List as="a" href="/">
+            전시회
+          </List>
+          <List as="a" href="/">
+            전시회 리뷰
+          </List>
+          <List as="a" href="/">
+            메이트 찾기
+          </List>
+          {/* <List as="a" href="/">
           전시회 정보 등록하기
         </List> */}
-      </ul>
-    </MenuWrapper>
-  </MenuContainer>
-);
+        </ul>
+      </MenuWrapper>
+    </MenuContainer>
+  );
+};
 
 export default HamburgerMenu;
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -66,16 +66,17 @@ const Login = () => {
     }
   };
 
-  // 로그인 성공 시 회원정보 로컬스토리지 저장 함수_박예선_23.01.24
+  // 로그인 성공 시 회원정보 로컬스토리지 저장 함수_박예선_23.01.25
   const setInfoToLocalStorage = async () => {
     try {
       const userRes: AxiosResponse<MyInfoRes> | void = await myInfoApi("get");
       if (!userRes) return;
-      const { userId, email, nickname, userImage, authority } = userRes.data;
-      localStorage.setItem("userId", String(userId));
+      const { memberId, email, nickname, memberImage, authority } =
+        userRes.data;
+      localStorage.setItem("memberId", String(memberId));
       localStorage.setItem("email", email);
       localStorage.setItem("nickname", nickname);
-      localStorage.setItem("userImage", userImage);
+      localStorage.setItem("memberImage", memberImage);
       localStorage.setItem("authority", authority);
       alert("로그인되었습니다.");
     } catch (err) {


### PR DESCRIPTION
1. 로그아웃 시 삭제되는 정보 추가(사용자 아이디, 이메일, 프로필, 닉네임(이름), 회원권한)
2. 로그아웃 테스트하며 내정보조회 api 응답 키이름 수정(api문서에 맞게)
3. 햄버거메뉴에 로그아웃 로직 반영(로그아웃 버튼 클릭 시 로그아웃 api 호출)
4. 로그인 시 로컬스토리지에 저장되는 정보고 키이름 수정(api문서에 맞게)