### PR TITLE
Fix: 페이지 수 0일 때 display:none 적용 #170

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -169,6 +169,9 @@ const PaginationContainer = styled.div`
   .flex {
     display: flex;
   }
+  &.none {
+    display: none;
+  }
 `;
 
 const ArrowBtn = styled.button`


### PR DESCRIPTION
props로 넘겨주는 페이지의 수가 0일 때 컴포넌트가 보여지지 않도록 수정했습니다.