### PR TITLE
Fix: 로그아웃, 리프레시 토큰 인증 api 수정

### DIFF
--- a/src/apis/logOut.tsx
+++ b/src/apis/logOut.tsx
@@ -1,13 +1,15 @@
 import { AxiosResponse } from "axios";
 import { useNavigate } from "react-router-dom";
+import useRefreshTokenApi from "./useRefreshToken";
 import apiInstance from "../utils/apiInstance";
 import isApiError from "../utils/isApiError";
 
-// 로그아웃 커스텀훅_박예선_2023.01.25
+// 로그아웃 커스텀훅_박예선_2023.01.30
 // 단순 로그아웃 시 호출: useLogOut();
 // refresh_token 만료 로그아웃 시 호출: useLogOut("refresh_token 만료");
-const useLogOut = (type?: "refreshToken 만료") => {
+const useLogOut = () => {
   const navigate = useNavigate();
+  const refreshTokenApi = useRefreshTokenApi();
 
   const logOut = async () => {
     try {
@@ -16,27 +18,41 @@ const useLogOut = (type?: "refreshToken 만료") => {
       );
       const { resultCode } = res.data;
       if (resultCode === 200) {
-        localStorage.removeItem("accessToken");
-        localStorage.removeItem("refreshToken");
-        localStorage.removeItem("memberId");
-        localStorage.removeItem("email");
-        localStorage.removeItem("nickname");
-        localStorage.removeItem("memberImage");
-        localStorage.removeItem("authority");
-        if (!type) {
-          alert("로그아웃되었습니다.");
-          navigate("/");
-          return;
-        }
+        removeLocalStorageItem();
+        alert("로그아웃되었습니다.");
+        navigate("/");
+        return;
       }
     } catch (err) {
-      isApiError(err);
+      const errorRes = isApiError(err);
+      if (errorRes === "accessToken 만료") {
+        refreshTokenApi();
+        const res: AxiosResponse<LogOutRes> = await apiInstance.post(
+          "/api/me/logout"
+        );
+        const { resultCode } = res.data;
+        if (resultCode === 200) {
+          removeLocalStorageItem();
+          alert("로그아웃되었습니다.");
+          navigate("/");
+        }
+      }
     }
   };
   return logOut;
 };
 
 export default useLogOut;
+
+function removeLocalStorageItem() {
+  localStorage.removeItem("accessToken");
+  localStorage.removeItem("refreshToken");
+  localStorage.removeItem("memberId");
+  localStorage.removeItem("email");
+  localStorage.removeItem("nickname");
+  localStorage.removeItem("memberImage");
+  localStorage.removeItem("authority");
+}
 
 interface LogOutRes {
   resultCode?: number;

--- a/src/apis/logOut.tsx
+++ b/src/apis/logOut.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import useRefreshTokenApi from "./useRefreshToken";
 import apiInstance from "../utils/apiInstance";
 import isApiError from "../utils/isApiError";
+import removeLocalStorageItem from "../utils/removeLocalStorageItem";
 
 // 로그아웃 커스텀훅_박예선_2023.01.30
 // 단순 로그아웃 시 호출: useLogOut();
@@ -43,16 +44,6 @@ const useLogOut = () => {
 };
 
 export default useLogOut;
-
-function removeLocalStorageItem() {
-  localStorage.removeItem("accessToken");
-  localStorage.removeItem("refreshToken");
-  localStorage.removeItem("memberId");
-  localStorage.removeItem("email");
-  localStorage.removeItem("nickname");
-  localStorage.removeItem("memberImage");
-  localStorage.removeItem("authority");
-}
 
 interface LogOutRes {
   resultCode?: number;

--- a/src/apis/useRefreshToken.tsx
+++ b/src/apis/useRefreshToken.tsx
@@ -1,13 +1,11 @@
 import { useNavigate } from "react-router-dom";
-import axios, { AxiosResponse } from "axios";
+import { AxiosResponse } from "axios";
 import apiInstance from "../utils/apiInstance";
-import useLogOut from "./logOut";
 import isApiError, { errorAlert } from "../utils/isApiError";
 
-// refresh토큰 요청 api_박예선_2023.01.23
+// refresh토큰 요청 api_박예선_2023.01.30
 const useRefreshTokenApi = () => {
   const navigate = useNavigate();
-  const logOut = useLogOut("refreshToken 만료");
   const token = localStorage.getItem("refreshToken");
 
   const refreshTokenApi = async () => {
@@ -18,7 +16,6 @@ const useRefreshTokenApi = () => {
           "/refresh",
           { refreshToken: `Bearer ${token}` }
         );
-        // await axios.get("/data/refreshToken.json"); // 테스트용 목데이터
         const { accessToken, refreshToken } = res.data;
         if (accessToken && refreshToken) {
           localStorage.setItem("accessToken", accessToken);
@@ -29,9 +26,16 @@ const useRefreshTokenApi = () => {
         if (typeof errorRes !== "object") return undefined;
         const { errorMsg } = errorRes;
         if (errorMsg === "Forbidden") {
-          await logOut();
+          localStorage.removeItem("accessToken");
+          localStorage.removeItem("refreshToken");
+          localStorage.removeItem("memberId");
+          localStorage.removeItem("email");
+          localStorage.removeItem("nickname");
+          localStorage.removeItem("memberImage");
+          localStorage.removeItem("authority");
           alert("자동 로그인 기간이 만료되었습니다. 다시 로그인해주세요.");
           navigate("/login");
+          return undefined;
         }
       }
     return undefined;

--- a/src/apis/useRefreshToken.tsx
+++ b/src/apis/useRefreshToken.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { AxiosResponse } from "axios";
 import apiInstance from "../utils/apiInstance";
 import isApiError, { errorAlert } from "../utils/isApiError";
+import removeLocalStorageItem from "../utils/removeLocalStorageItem";
 
 // refresh토큰 요청 api_박예선_2023.01.30
 const useRefreshTokenApi = () => {
@@ -26,13 +27,7 @@ const useRefreshTokenApi = () => {
         if (typeof errorRes !== "object") return undefined;
         const { errorMsg } = errorRes;
         if (errorMsg === "Forbidden") {
-          localStorage.removeItem("accessToken");
-          localStorage.removeItem("refreshToken");
-          localStorage.removeItem("memberId");
-          localStorage.removeItem("email");
-          localStorage.removeItem("nickname");
-          localStorage.removeItem("memberImage");
-          localStorage.removeItem("authority");
+          removeLocalStorageItem();
           alert("자동 로그인 기간이 만료되었습니다. 다시 로그인해주세요.");
           navigate("/login");
           return undefined;

--- a/src/utils/removeLocalStorageItem.tsx
+++ b/src/utils/removeLocalStorageItem.tsx
@@ -1,0 +1,11 @@
+function removeLocalStorageItem() {
+  localStorage.removeItem("accessToken");
+  localStorage.removeItem("refreshToken");
+  localStorage.removeItem("memberId");
+  localStorage.removeItem("email");
+  localStorage.removeItem("nickname");
+  localStorage.removeItem("memberImage");
+  localStorage.removeItem("authority");
+}
+
+export default removeLocalStorageItem;


### PR DESCRIPTION
api 로직 변경요청이 들어와서 그에맞게 수정했습니다.
1. 로그아웃 할 때도 ACCESS토큰 만료 응답 받을 수 있고, 해당 응답 받을 시 리프레시 토큰 인증api 호출하도록 api 수정
2. 로컬스토리지에서 회원정보, 토큰을 다 삭제하는 함수 생성. 유지보수를 위해 하나의 함수를 생성 후 필요한 파일에서 호출하여 사용했습니다.