### PR TITLE
Refactor: 배포 전 점검(목데이터 말고 api로 연결, css 깨짐 수정, NoList컴포넌트 props추가)

### DIFF
--- a/src/apis/getExhbList.tsx
+++ b/src/apis/getExhbList.tsx
@@ -1,4 +1,4 @@
-import axios, { AxiosResponse } from "axios";
+import { AxiosResponse } from "axios";
 import { StatusType } from "../components/exhibitionList/Filters";
 import { Exhibition, FilterType } from "../types/exhbList";
 import apiInstance from "../utils/apiInstance";
@@ -18,19 +18,15 @@ const exhbListApi = async (
   type: FilterType,
   page: number
 ) => {
-  if (type === "전체") {
-    const res: AxiosResponse<ExhbListRes> =
-      //   await apiInstance.get(
-      //   `/main/exhibitions/?status=${status}전시&page=${page}`
-      // );
-      await axios.get("/data/exhbList.json"); // 테스트용 목데이터
+  if (type === "전체 전시") {
+    const res: AxiosResponse<ExhbListRes> = await apiInstance.get(
+      `/main/exhibitions/?status=${status} 전시&page=${page}`
+    );
     return res;
   }
-  const res: AxiosResponse<ExhbListRes> =
-    //   await apiInstance.get(
-    //   `/exhibitions/?status=${status}전시&type=${type}전시&page=${page}`
-    // );
-    await axios.get("/data/exhbListFiltered.json"); // 테스트용 목데이터
+  const res: AxiosResponse<ExhbListRes> = await apiInstance.get(
+    `/exhibitions/?status=${status} 전시&type=${type}&page=${page}`
+  );
   return res;
 };
 

--- a/src/apis/mate.tsx
+++ b/src/apis/mate.tsx
@@ -1,4 +1,4 @@
-import axios, { AxiosResponse } from "axios";
+import { AxiosResponse } from "axios";
 import apiInstance from "../utils/apiInstance";
 import useLogOut from "./logOut";
 import useRefreshTokenApi from "./useRefreshToken";
@@ -56,11 +56,9 @@ export interface BookMarkRes {
 
 // 메이트 목록 조회 api_박예선_23.01.26
 export const mateListApi = async (status: MateStatusType, page: number) => {
-  const res: AxiosResponse<MateListType> =
-    //   await apiInstance.get(
-    //   `/mates?page=${page}&status=${status.replace(" ", "")}`
-    // );
-    await axios.get("/data/mateList.json"); // 테스트용 목데이터
+  const res: AxiosResponse<MateListType> = await apiInstance.get(
+    `/mates?page=${page}&status=${status === "전체" ? "" : status}`
+  );
   return res;
 };
 

--- a/src/components/NoList.tsx
+++ b/src/components/NoList.tsx
@@ -2,11 +2,15 @@ import React from "react";
 import styled from "styled-components";
 import { theme } from "../styles/theme";
 
-const NoList = () => (
-  <NoListContainer>
-    <Content>아직 작성한 글이 없습니다</Content>
-  </NoListContainer>
-);
+const NoList = (props: { notice: string }) => {
+  const { notice } = props;
+
+  return (
+    <NoListContainer>
+      <Content>{notice}</Content>
+    </NoListContainer>
+  );
+};
 
 export default NoList;
 

--- a/src/components/exhibition/ExhbMateList.tsx
+++ b/src/components/exhibition/ExhbMateList.tsx
@@ -56,7 +56,7 @@ const ExhbMateList = () => {
         </a>
       </Header>
       {mateList.length === 0 ? (
-        <NoList />
+        <NoList notice="아직 작성한 글이 없습니다" />
       ) : (
         mateList.map((mate) => <MateCard key={mate.mateId} mate={mate} />)
       )}

--- a/src/components/exhibitionList/ExhbCardList.tsx
+++ b/src/components/exhibitionList/ExhbCardList.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { Exhibition } from "../../types/exhbList";
 import { theme } from "../../styles/theme";
+import NoList from "../NoList";
 
 interface ExhbCardListType {
   exhbList: Exhibition[]; // 전시회 목록 데이터
@@ -11,6 +12,7 @@ interface ExhbCardListType {
 
 const ExhbCardList = ({ exhbList, type }: ExhbCardListType) => (
   <CardListContainer>
+    {exhbList.length === 0 && <NoList notice="등록된 전시글이 없습니다" />}
     {exhbList.map((exhb) => {
       const { id, title, space, duration, posterUrl, viewCount } = exhb;
       return (

--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -42,7 +42,6 @@ const Filters = (props: FiltersType) => {
 
   // 필터 적용버튼 클릭 함수_박예선_23.01.18
   const clickFilterApplyBtn = () => {
-    return alert("준비중인 기능입니다."); // 백엔드 코드 수정되면 삭제
     getExhbList(selectedStatus, exhbTypeFilters.selected, 1);
     setExhbTypeFilters({
       ...exhbTypeFilters,

--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -42,6 +42,7 @@ const Filters = (props: FiltersType) => {
 
   // 필터 적용버튼 클릭 함수_박예선_23.01.18
   const clickFilterApplyBtn = () => {
+    return alert("준비중인 기능입니다."); // 백엔드 코드 수정되면 삭제
     getExhbList(selectedStatus, exhbTypeFilters.selected, 1);
     setExhbTypeFilters({
       ...exhbTypeFilters,

--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import styled from "styled-components";
 import { ExhbTypeFilters, FilterType } from "../../types/exhbList";
+import Selectbox from "../atom/Selectbox";
 import { PagesState } from "../Pagination";
 
+// 전시글 목록 상단 필터 컴포넌트_박예선_23.01.18
 const Filters = (props: FiltersType) => {
   const {
     setPages,
@@ -16,18 +18,19 @@ const Filters = (props: FiltersType) => {
   // 전시상황 버튼 클릭 함수_박예선_23.01.18
   const handleStatusBtn = (status: StatusType) => {
     if (exhbTypeFilters.applied !== exhbTypeFilters.selected) {
-      alert("필터 적용버튼을 먼저 클릭하세요");
+      alert("필터 적용버튼을 먼저 클릭하세요.");
       return;
     }
     setPages({ started: 1, selected: 1 });
     setSelectedStatus(status);
   };
 
-  // 필터 조건 핸들 함수_박예선_23.01.17
-  const handleFilters = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const { value } = e.target;
+  // 필터 조건 핸들 함수_박예선_23.02.01
+  const handleFilters = (e: React.MouseEvent<HTMLLIElement>) => {
+    const value = e.currentTarget.textContent;
+    if (!value) return;
     if (value === "인기순") {
-      alert("준비 중인 기능입니다.");
+      alert("준비중인 기능입니다.");
       return;
     }
     for (let i = 0; i < EXHB_TYPE_ARRAY.length; i += 1) {
@@ -63,24 +66,20 @@ const Filters = (props: FiltersType) => {
       </div>
       <div className="filter-search-line flex space-between">
         <div>
-          <select className="sort border" onChange={handleFilters}>
-            {EXHB_SORT_ARRAY.map((sort) => (
-              <option key={sort} value={sort}>
-                {sort}
-              </option>
-            ))}
-          </select>
-          <select
-            value={exhbTypeFilters.selected}
-            className="type border"
-            onChange={handleFilters}
-          >
-            {EXHB_TYPE_ARRAY.map((type) => (
-              <option key={type} value={type}>
-                {type} 전시
-              </option>
-            ))}
-          </select>
+          <Selectbox
+            options={EXHB_SORT_ARRAY}
+            placeholder="최신순"
+            width="130px"
+            name="sort"
+            onClick={handleFilters}
+          />
+          <Selectbox
+            options={EXHB_TYPE_ARRAY}
+            placeholder="전체 전시"
+            width="130px"
+            name="type"
+            onClick={handleFilters}
+          />
           <button
             type="button"
             className="apply-btn"
@@ -100,12 +99,12 @@ export default Filters;
 const EXHB_STATUS_ARRAY: StatusType[] = ["현재", "예정", "지난"];
 const EXHB_SORT_ARRAY = ["최신순", "인기순"];
 export const EXHB_TYPE_ARRAY: FilterType[] = [
-  "전체",
-  "영상",
-  "특별",
-  "기획",
-  "상설",
-  "소장품",
+  "전체 전시",
+  "영상 전시",
+  "특별 전시",
+  "기획 전시",
+  "상설 전시",
+  "소장품 전시",
 ];
 
 interface FiltersType {
@@ -127,6 +126,7 @@ const FiltersContainer = styled.div`
   align-items: center;
   flex-direction: column;
   width: inherit;
+  margin-bottom: 30px;
   .status-filter {
     width: 300px;
     height: 36px;

--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -65,7 +65,7 @@ const Filters = (props: FiltersType) => {
         ))}
       </div>
       <div className="filter-search-line flex space-between">
-        <div>
+        <div className="flex select-container">
           <Selectbox
             options={EXHB_SORT_ARRAY}
             placeholder="최신순"
@@ -151,7 +151,6 @@ const FiltersContainer = styled.div`
     padding-top: 14px;
     border-top: 1px solid ${(props) => props.theme.colors.greys40};
     border-radius: 0%;
-    select,
     input,
     button {
       height: 36px;
@@ -159,26 +158,9 @@ const FiltersContainer = styled.div`
       padding-left: 20px;
       cursor: pointer;
     }
-    select {
-      margin-right: 10px;
-      border-radius: 30px;
-      color: ${(props) => props.theme.colors.greys60};
-      background: url("data:image/svg+xml,%3Csvg width='12' height='7' viewBox='0 0 12 7' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11.2998 1.69995L6.6998 6.29995C6.5998 6.39995 6.49147 6.47062 6.3748 6.51195C6.25814 6.55395 6.13314 6.57495 5.9998 6.57495C5.86647 6.57495 5.74147 6.55395 5.6248 6.51195C5.50814 6.47062 5.3998 6.39995 5.2998 6.29995L0.699804 1.69995C0.516471 1.51662 0.424804 1.28328 0.424804 0.999951C0.424804 0.716618 0.516471 0.483285 0.699804 0.299952C0.883137 0.116618 1.11647 0.024951 1.3998 0.0249509C1.68314 0.0249509 1.91647 0.116618 2.0998 0.299951L5.9998 4.19995L9.8998 0.299951C10.0831 0.116618 10.3165 0.0249505 10.5998 0.0249505C10.8831 0.0249505 11.1165 0.116618 11.2998 0.299951C11.4831 0.483284 11.5748 0.716618 11.5748 0.999951C11.5748 1.28328 11.4831 1.51662 11.2998 1.69995Z' fill='%239C9C9C'/%3E%3C/svg%3E%0A")
-        no-repeat;
-      background-size: 11.15px 6.55px;
-      background-position: right 16px center;
-      -webkit-appearance: none;
-      -moz-appearance: none;
-      appearance: none;
-      &.sort {
-        width: 102px;
-      }
-      &.type {
-        width: 117px;
-      }
-      &:focus {
-        border: 1px solid #7f67be;
-        outline: none;
+    .select-container {
+      div {
+        margin-right: 10px;
       }
     }
     .apply-btn {

--- a/src/components/main/MainArticle.tsx
+++ b/src/components/main/MainArticle.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
-import ArrowButton from "../assets/icons/arrowRight.svg";
+import arrowRight from "../../assets/icons/arrowRight.svg";
 import { theme } from "../../styles/theme";
 
 const MainArticle = () => (
@@ -14,7 +14,7 @@ const MainArticle = () => (
       </div>
       <StyledLink to="/exhibition-list">
         <span>자세히 보기</span>
-        <img src={ArrowButton} alt="" />
+        <img src={arrowRight} alt="" />
       </StyledLink>
     </Article>
     <Article>
@@ -25,7 +25,7 @@ const MainArticle = () => (
       </div>
       <StyledLink to="">
         <span>자세히 보기</span>
-        <img src={ArrowButton} alt="" />
+        <img src={arrowRight} alt="" />
       </StyledLink>
     </Article>
     <Article>
@@ -36,7 +36,7 @@ const MainArticle = () => (
       </div>
       <StyledLink to="/mate-list">
         <span>자세히 보기</span>
-        <img src={ArrowButton} alt="" />
+        <img src={arrowRight} alt="" />
       </StyledLink>
     </Article>
   </ArticleContainer>

--- a/src/components/mate/MateCard.tsx
+++ b/src/components/mate/MateCard.tsx
@@ -151,6 +151,7 @@ const Card = styled.div`
 const Thumbnail = styled.img`
   width: 175px;
   height: 100%;
+  object-fit: cover;
 `;
 
 const FindMateDetail = styled.div`

--- a/src/components/mypage/BookMarkedExhb.tsx
+++ b/src/components/mypage/BookMarkedExhb.tsx
@@ -60,7 +60,7 @@ const BookMarkedExhb = () => {
   return (
     <div>
       {exhibitionList.length === 0 ? (
-        <NoList />
+        <NoList notice="아직 작성한 글이 없습니다" />
       ) : (
         <ExhbCardList exhbList={exhibitionList} type="myPage" />
       )}

--- a/src/components/mypage/BookMarkedMate.tsx
+++ b/src/components/mypage/BookMarkedMate.tsx
@@ -55,7 +55,7 @@ const BookMarkedMate = () => {
   return (
     <div>
       {matesList.length === 0 ? (
-        <NoList />
+        <NoList notice="아직 작성한 글이 없습니다" />
       ) : (
         matesList.map((mate) => <MateCard key={mate.mateId} mate={mate} />)
       )}

--- a/src/components/mypage/WrittenMate.tsx
+++ b/src/components/mypage/WrittenMate.tsx
@@ -58,7 +58,7 @@ const WrittenMate = () => {
   return (
     <FindMateContainer>
       {matesList.length === 0 ? (
-        <NoList />
+        <NoList notice="아직 작성한 글이 없습니다" />
       ) : (
         matesList.map((mate) => <MateCard key={mate.mateId} mate={mate} />)
       )}

--- a/src/components/signUp/EmailAndPw.tsx
+++ b/src/components/signUp/EmailAndPw.tsx
@@ -73,7 +73,7 @@ const EmailAndPw = (props: EmailAndPwType) => {
         <input
           type="email"
           name="email"
-          placeholder="ex_mail@exhibition.com"
+          placeholder="이메일을 입력하세요"
           value={infos.email}
           onChange={(e) => {
             handleInput(e);
@@ -101,7 +101,7 @@ const EmailAndPw = (props: EmailAndPwType) => {
         <input
           type="password"
           name="password"
-          placeholder="Password"
+          placeholder="비밀번호를 입력하세요"
           value={infos.password}
           onChange={(e) => {
             handleInput(e);
@@ -127,7 +127,7 @@ const EmailAndPw = (props: EmailAndPwType) => {
         <input
           type="password"
           name="pwCheck"
-          placeholder="Password"
+          placeholder="비밀번호를 다시 입력하세요"
           value={infos.pwCheck}
           onChange={(e) => {
             handleInput(e);

--- a/src/pages/ExhibitionList.tsx
+++ b/src/pages/ExhibitionList.tsx
@@ -30,7 +30,6 @@ const ExhibitionList = () => {
           type,
           page
         );
-        console.log(res);
         const { exhibitions, pageInfo } = res.data;
         setExhbList(exhibitions);
         setTotalPage(pageInfo.totalPage);
@@ -45,7 +44,6 @@ const ExhibitionList = () => {
 
   // 전시상태, 전시유형 필터, 페이지 번호에 따라 전시목록 불러오는 로직_박예선_23.01.18
   useEffect(() => {
-    // console.log("바뀜");
     getExhbList(selectedStatus, exhbTypeFilters.applied, pages.selected);
   }, [getExhbList, selectedStatus, exhbTypeFilters.applied, pages.selected]);
 

--- a/src/pages/ExhibitionList.tsx
+++ b/src/pages/ExhibitionList.tsx
@@ -13,8 +13,8 @@ const ExhibitionList = () => {
   const [totalPage, setTotalPage] = useState<number>(0);
   const [selectedStatus, setSelectedStatus] = useState<StatusType>("현재");
   const [exhbTypeFilters, setExhbTypeFilters] = useState<ExhbTypeFilters>({
-    selected: "전체",
-    applied: "전체",
+    selected: "전체 전시",
+    applied: "전체 전시",
   });
   const [pages, setPages] = useState({
     started: 1,
@@ -30,6 +30,7 @@ const ExhibitionList = () => {
           type,
           page
         );
+        console.log(res);
         const { exhibitions, pageInfo } = res.data;
         setExhbList(exhibitions);
         setTotalPage(pageInfo.totalPage);
@@ -44,6 +45,7 @@ const ExhibitionList = () => {
 
   // 전시상태, 전시유형 필터, 페이지 번호에 따라 전시목록 불러오는 로직_박예선_23.01.18
   useEffect(() => {
+    // console.log("바뀜");
     getExhbList(selectedStatus, exhbTypeFilters.applied, pages.selected);
   }, [getExhbList, selectedStatus, exhbTypeFilters.applied, pages.selected]);
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -11,7 +11,7 @@ import loginApi, { LoginRes } from "../apis/login";
 import { myInfoApi, MyInfoRes } from "../apis/member";
 import isApiError from "../utils/isApiError";
 
-// 로그인 컴포넌트_박예선_23.01.23
+// 로그인 컴포넌트_박예선_23.02.01
 const Login = () => {
   const navigate = useNavigate();
   const [loginInfo, setLoginInfo] = useState({ email: "", password: "" });
@@ -146,9 +146,13 @@ const Login = () => {
           회원가입
         </Button>
         <div className="find-account">
-          <Link to="/">비밀번호 찾기</Link>
+          <Link to="/login" onClick={() => alert("준비중인 기능입니다.")}>
+            비밀번호 찾기
+          </Link>
           <div className="line" />
-          <Link to="/">아이디 찾기</Link>
+          <Link to="/login" onClick={() => alert("준비중인 기능입니다.")}>
+            이메일 찾기
+          </Link>
         </div>
       </BtnContainer>
     </LoginSignUp>

--- a/src/pages/MateList.tsx
+++ b/src/pages/MateList.tsx
@@ -11,8 +11,9 @@ import { Mate, MateListType } from "../types/mateList";
 import { theme } from "../styles/theme";
 import { mateListApi } from "../apis/mate";
 import { errorAlert } from "../utils/isApiError";
+import NoList from "../components/NoList";
 
-// 메이트글 목록 페이지_박예선_23.01.26
+// 메이트글 목록 페이지_박예선_23.02.01
 const MateList = () => {
   const [mateList, setMateList] = useState<Mate[] | null>(null);
   const [mateStatusFilter, setMateStatusFilter] = useState<MateStatusSelect>({
@@ -53,6 +54,7 @@ const MateList = () => {
         setMateStatusFilter={setMateStatusFilter}
         setPages={setPages}
       />
+      {mateList?.length === 0 && <NoList notice="작성된 메이트글이 없습니다" />}
       {mateList?.map((mate) => (
         <MateCard key={mate.mateId} mate={mate} />
       ))}

--- a/src/types/exhbList.d.ts
+++ b/src/types/exhbList.d.ts
@@ -14,4 +14,10 @@ export interface ExhbTypeFilters {
   applied: FilterType;
 }
 
-export type FilterType = "전체" | "영상" | "특별" | "기획" | "상설" | "소장품";
+export type FilterType =
+  | "전체 전시"
+  | "영상 전시"
+  | "특별 전시"
+  | "기획 전시"
+  | "상설 전시"
+  | "소장품 전시";


### PR DESCRIPTION
1. NoList 컴포넌트에 프롭스 추가했습니다. notice:string을 넘겨줍니다. 기존에 사용되던 NoList 컴포넌트들은 기존 문구로 다 넘겨주었습니다.
2. 로그인/회원가입 시 아이디 -> 이메일로 수정했습니다. 아이디/비밀번호 찾기 기능은 아직 없기 때문에 클릭 시 alert창이 뜨도록 수정했습니다.
3. 전시글 목록페이지의 필터가 SelectBox로 적용되지 않은 것을 발견해 적용했습니다. 
4. api연결이 되지 않고 목데이터로 연결되어있던 부분들 api로 연결했습니다
    (전시글 목록 조회에서 전체전시 제외하고 기획전시, 영상전시 등은 현재 필터링이 제대로 되지 않고 데이터가 들어와서 그 부분 확인요청드린 상태입니다. ➡️ api 수정완료해주셔서 기능 비활성화 풀었습니다)
5. 전시글 목록 페이지 전시타입 필터 적용막아놨습니다. 백엔드 수정이 필요할 것 같은데 당장 불가능 할 것 같아서 막아달라고 요청이 들어왔습니다. 리팩토링 끝나고 나면 다시 적용할 예정입니다
6. 동규님 머지과정에서 MainArticle파일에서 에러를 발견해 수정했습니다.
    
    
  따로 기능별로 브랜치를 분리하지 않고 feature/refactor-yesun 브랜치에서 전체적인 수정사항을 수정했습니다.
머지되면 브랜치는 삭제하겠습니다.