### PR TITLE
Fix: 전시회 목록 필터적용 버튼 삭제 #216

### DIFF
--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -4,12 +4,12 @@ import { FilterType } from "../../types/exhbList";
 import Selectbox from "../atom/Selectbox";
 import { PagesState } from "../Pagination";
 
-// 전시글 목록 상단 필터 컴포넌트_박예선_23.01.18
+// 전시글 목록 상단 필터 컴포넌트_박예선_23.02.01
 const Filters = (props: FiltersType) => {
   const { setPages, selectedStatus, setSelectedStatus, setSelectedFilter } =
     props;
 
-  // 전시상황 버튼 클릭 함수_박예선_23.01.18
+  // 전시상황 버튼 클릭 함수_박예선_23.02.01
   const handleStatusBtn = (status: StatusType) => {
     setPages({ started: 1, selected: 1 });
     setSelectedStatus(status);

--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -1,26 +1,16 @@
 import React from "react";
 import styled from "styled-components";
-import { ExhbTypeFilters, FilterType } from "../../types/exhbList";
+import { FilterType } from "../../types/exhbList";
 import Selectbox from "../atom/Selectbox";
 import { PagesState } from "../Pagination";
 
 // 전시글 목록 상단 필터 컴포넌트_박예선_23.01.18
 const Filters = (props: FiltersType) => {
-  const {
-    setPages,
-    selectedStatus,
-    setSelectedStatus,
-    exhbTypeFilters,
-    setExhbTypeFilters,
-    getExhbList,
-  } = props;
+  const { setPages, selectedStatus, setSelectedStatus, setSelectedFilter } =
+    props;
 
   // 전시상황 버튼 클릭 함수_박예선_23.01.18
   const handleStatusBtn = (status: StatusType) => {
-    if (exhbTypeFilters.applied !== exhbTypeFilters.selected) {
-      alert("필터 적용버튼을 먼저 클릭하세요.");
-      return;
-    }
     setPages({ started: 1, selected: 1 });
     setSelectedStatus(status);
   };
@@ -35,19 +25,9 @@ const Filters = (props: FiltersType) => {
     }
     for (let i = 0; i < EXHB_TYPE_ARRAY.length; i += 1) {
       if (value === EXHB_TYPE_ARRAY[i]) {
-        setExhbTypeFilters({ ...exhbTypeFilters, selected: value });
+        setSelectedFilter(value);
       }
     }
-  };
-
-  // 필터 적용버튼 클릭 함수_박예선_23.01.18
-  const clickFilterApplyBtn = () => {
-    getExhbList(selectedStatus, exhbTypeFilters.selected, 1);
-    setExhbTypeFilters({
-      ...exhbTypeFilters,
-      applied: exhbTypeFilters.selected,
-    });
-    setPages({ started: 1, selected: 1 });
   };
 
   return (
@@ -80,13 +60,6 @@ const Filters = (props: FiltersType) => {
             name="type"
             onClick={handleFilters}
           />
-          <button
-            type="button"
-            className="apply-btn"
-            onClick={clickFilterApplyBtn}
-          >
-            적용
-          </button>
         </div>
         <input placeholder="검색" className="search-input border" />
       </div>
@@ -111,13 +84,7 @@ interface FiltersType {
   setPages: React.Dispatch<React.SetStateAction<PagesState>>;
   selectedStatus: StatusType;
   setSelectedStatus: React.Dispatch<React.SetStateAction<StatusType>>;
-  exhbTypeFilters: ExhbTypeFilters;
-  setExhbTypeFilters: React.Dispatch<React.SetStateAction<ExhbTypeFilters>>;
-  getExhbList: (
-    status: StatusType,
-    type: FilterType,
-    page: number
-  ) => Promise<void>;
+  setSelectedFilter: React.Dispatch<React.SetStateAction<FilterType>>;
 }
 export type StatusType = "현재" | "예정" | "지난";
 

--- a/src/pages/ExhibitionList.tsx
+++ b/src/pages/ExhibitionList.tsx
@@ -7,7 +7,7 @@ import Pagination from "../components/Pagination";
 import Filters, { StatusType } from "../components/exhibitionList/Filters";
 import ExhbCardList from "../components/exhibitionList/ExhbCardList";
 
-// 전시회 목록 페이지 컴포넌트_박예선_23.01.21
+// 전시회 목록 페이지 컴포넌트_박예선_23.02.01
 const ExhibitionList = () => {
   const [exhbList, setExhbList] = useState<Exhibition[]>([]);
   const [totalPage, setTotalPage] = useState<number>(0);
@@ -17,6 +17,7 @@ const ExhibitionList = () => {
     started: 1,
     selected: 1,
   });
+
   // 전시회 목록 요청 api_박예선_23.01.18
   const getExhbList = useCallback(
     async (status: StatusType, type: FilterType, page: number) => {
@@ -38,7 +39,7 @@ const ExhibitionList = () => {
     []
   );
 
-  // 전시상태, 전시유형 필터, 페이지 번호에 따라 전시목록 불러오는 로직_박예선_23.01.18
+  // 전시상태, 전시유형 필터, 페이지 번호에 따라 전시목록 불러오는 로직_박예선_23.02.01
   useEffect(() => {
     getExhbList(selectedStatus, selectedFilter, pages.selected);
   }, [getExhbList, selectedStatus, selectedFilter, pages.selected]);

--- a/src/pages/ExhibitionList.tsx
+++ b/src/pages/ExhibitionList.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { AxiosResponse } from "axios";
 import styled from "styled-components";
-import { ExhbTypeFilters, Exhibition, FilterType } from "../types/exhbList";
+import { Exhibition, FilterType } from "../types/exhbList";
 import exhbListApi, { ExhbListRes } from "../apis/getExhbList";
 import Pagination from "../components/Pagination";
 import Filters, { StatusType } from "../components/exhibitionList/Filters";
@@ -12,10 +12,7 @@ const ExhibitionList = () => {
   const [exhbList, setExhbList] = useState<Exhibition[]>([]);
   const [totalPage, setTotalPage] = useState<number>(0);
   const [selectedStatus, setSelectedStatus] = useState<StatusType>("현재");
-  const [exhbTypeFilters, setExhbTypeFilters] = useState<ExhbTypeFilters>({
-    selected: "전체 전시",
-    applied: "전체 전시",
-  });
+  const [selectedFilter, setSelectedFilter] = useState<FilterType>("전체 전시");
   const [pages, setPages] = useState({
     started: 1,
     selected: 1,
@@ -43,8 +40,8 @@ const ExhibitionList = () => {
 
   // 전시상태, 전시유형 필터, 페이지 번호에 따라 전시목록 불러오는 로직_박예선_23.01.18
   useEffect(() => {
-    getExhbList(selectedStatus, exhbTypeFilters.applied, pages.selected);
-  }, [getExhbList, selectedStatus, exhbTypeFilters.applied, pages.selected]);
+    getExhbList(selectedStatus, selectedFilter, pages.selected);
+  }, [getExhbList, selectedStatus, selectedFilter, pages.selected]);
 
   return (
     <ExhibitionListContainer className="flex">
@@ -53,9 +50,7 @@ const ExhibitionList = () => {
         selectedStatus={selectedStatus}
         setSelectedStatus={setSelectedStatus}
         setPages={setPages}
-        exhbTypeFilters={exhbTypeFilters}
-        setExhbTypeFilters={setExhbTypeFilters}
-        getExhbList={getExhbList}
+        setSelectedFilter={setSelectedFilter}
       />
       <ExhbCardList exhbList={exhbList} type="exhbList" />
       <Pagination pages={pages} setPages={setPages} totalPage={totalPage} />

--- a/src/types/exhbList.d.ts
+++ b/src/types/exhbList.d.ts
@@ -9,11 +9,6 @@ export interface Exhibition {
   viewCount: number;
 }
 
-export interface ExhbTypeFilters {
-  selected: FilterType;
-  applied: FilterType;
-}
-
 export type FilterType =
   | "전체 전시"
   | "영상 전시"


### PR DESCRIPTION
기획분들과 상의하여 전시회 목록에서 필터 적용 버튼을 삭제하고,
필터를 선택하면 바로 목록을 불러들이는 로직으로 변경했습니다.
메이트 모집글도 필터 적용버튼 없애기로 했으니 곧 작업해서 pr하겠습니다