### PR TITLE
Design: Button 컴포넌트 focus, active 시 빠진 디자인 추가

### DIFF
--- a/src/components/atom/Button.tsx
+++ b/src/components/atom/Button.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import { theme } from "../../styles/theme";
 
+// default, Tab focus 시(피그마 state=focus) 공통
 const backgroundColor = {
   primary: `${theme.colors.primry70}`,
   secondary: `${theme.colors.greys60}`,
@@ -11,6 +12,13 @@ const hoverBackgroundColor = {
   primary: `${theme.colors.primry80}`,
   secondary: `${theme.colors.greys90}`,
   text: `${theme.colors.greys10}`,
+};
+
+// 피그마 state = active
+const focusBackgroundColor = {
+  primary: `${theme.colors.primry80}`,
+  secondary: `${theme.colors.greys90}`,
+  text: `${theme.colors.white100}`,
 };
 
 const disabledBackgroundColor = {
@@ -37,7 +45,7 @@ const disabledFontColor = {
   text: `${theme.colors.greys40}`,
 };
 
-const buttonsize = {
+const buttonSize = {
   small: "20px",
   large: "40px",
 };
@@ -50,7 +58,7 @@ interface ButtonProps {
 const Button = styled.button<ButtonProps>`
   padding-top: 10px;
   padding-bottom: 10px;
-  padding-inline: ${(props) => buttonsize[props.size]};
+  padding-inline: ${(props) => buttonSize[props.size]};
   border: 0;
   border-radius: 30px;
   font-weight: bold;
@@ -60,12 +68,21 @@ const Button = styled.button<ButtonProps>`
   cursor: pointer;
   &:is(:hover, :focus) {
     color: ${(props) => hoverFontColor[props.variant]};
+  }
+  :hover {
     background-color: ${(props) => hoverBackgroundColor[props.variant]};
+  }
+  :focus {
+    background-color: ${(props) => focusBackgroundColor[props.variant]};
   }
   :disabled {
     background-color: ${(props) => disabledBackgroundColor[props.variant]};
     color: ${(props) => disabledFontColor[props.variant]};
     cursor: default;
+  }
+  :focus-visible {
+    border: 2px solid ${theme.colors.greys100};
+    background-color: ${(props) => backgroundColor[props.variant]};
   }
 `;
 


### PR DESCRIPTION
공통 버튼 컴포넌트 누락된 디자인 추가했습니다!
호버와 포커스 시 배경색이 다른 게 있는데 똑같게 되어있어서 그 부분도 수정했습니다

1. 탭키로 포커스 했을 때 디자인 누락되어있어 추가
2. focus (선택되었을 때, 피그마 상에선 active) 배경색 알맞게 수정
3. buttonsize 변수명 컨벤션에 맞게 수정

브랜치는 머지후 삭제예정입니다