### PR TITLE
Design: 전시회 목록페이지 max-width추가, 공통 버튼 컴포넌트로 변경

### DIFF
--- a/src/components/atom/Button.tsx
+++ b/src/components/atom/Button.tsx
@@ -60,12 +60,21 @@ const Button = styled.button<ButtonProps>`
   cursor: pointer;
   &:is(:hover, :focus) {
     color: ${(props) => hoverFontColor[props.variant]};
+  }
+  :hover {
     background-color: ${(props) => hoverBackgroundColor[props.variant]};
+  }
+  :focus {
+    background-color: transparent;
   }
   :disabled {
     background-color: ${(props) => disabledBackgroundColor[props.variant]};
     color: ${(props) => disabledFontColor[props.variant]};
     cursor: default;
+  }
+  :focus-visible {
+    border: 1px solid ${theme.colors.greys100};
+    background-color: transparent;
   }
 `;
 

--- a/src/components/exhibitionList/ExhbCardList.tsx
+++ b/src/components/exhibitionList/ExhbCardList.tsx
@@ -44,6 +44,7 @@ const CardListContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
   width: inherit;
+  max-width: 1440px;
 `;
 
 const ExhibitionCard = styled.div<{

--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import styled from "styled-components";
+import { theme } from "../../styles/theme";
 import { FilterType } from "../../types/exhbList";
+import Button from "../atom/Button";
 import Selectbox from "../atom/Selectbox";
 import { PagesState } from "../Pagination";
 
@@ -34,14 +36,15 @@ const Filters = (props: FiltersType) => {
     <FiltersContainer>
       <div className="status-filter flex space-between">
         {EXHB_STATUS_ARRAY.map((status) => (
-          <button
+          <Button
             key={status}
-            type="button"
-            className={selectedStatus === status ? "selected" : ""}
+            variant="text"
+            size="small"
             onClick={() => handleStatusBtn(status)}
+            className={selectedStatus === status ? "selected" : ""}
           >
             {status} 전시
-          </button>
+          </Button>
         ))}
       </div>
       <div className="filter-search-line flex space-between">
@@ -100,16 +103,12 @@ const FiltersContainer = styled.div`
     margin-bottom: 14px;
     font-size: 14px;
     button {
-      justify-content: center;
+      display: flex;
       align-items: center;
-      width: 93px;
-      height: inherit;
-      color: ${(props) => props.theme.colors.greys60};
       font-size: 14px;
-      font-weight: 700;
       cursor: pointer;
       &.selected {
-        color: #1c1c1c;
+        color: ${theme.colors.greys100};
       }
     }
   }

--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -115,6 +115,7 @@ const FiltersContainer = styled.div`
   }
   .filter-search-line {
     width: inherit;
+    max-width: 1440px;
     padding-top: 14px;
     border-top: 1px solid ${(props) => props.theme.colors.greys40};
     border-radius: 0%;

--- a/src/pages/ExhibitionList.tsx
+++ b/src/pages/ExhibitionList.tsx
@@ -65,6 +65,8 @@ const ExhibitionListContainer = styled.div`
   flex-direction: column;
   align-items: center;
   width: 100vw;
+  max-width: 1440px;
+  margin: auto;
   font-size: 14px;
   h1 {
     margin: 50px 0;


### PR DESCRIPTION
1. 전시회 목록 페이지 카드리스트와 필터컴포넌트의 max-width가 설정되어있지 않아서 추가
2. 전시 상태 필터를 공통 버튼 컴포넌트로 변경