### PR TITLE
Fix: 전시회 상세페이지에 들어가면 최상단으로 스크롤 올라오도록 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { ReactQueryDevtools } from "react-query/devtools";
+import ScrollTop from "./components/ScrollTop";
 import Nav from "./components/Nav";
 import Main from "./pages/Main";
 import Login from "./pages/Login";
@@ -16,6 +17,7 @@ import Footer from "./components/Footer";
 
 const App = () => (
   <BrowserRouter>
+    <ScrollTop />
     <Nav />
     <Routes>
       <Route path="/" element={<Main />} />

--- a/src/components/ScrollTop.tsx
+++ b/src/components/ScrollTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollTop;

--- a/src/pages/Exhibition.tsx
+++ b/src/pages/Exhibition.tsx
@@ -37,10 +37,6 @@ const Exhibition = () => {
     getExhbDetail();
   }, [getExhbDetail]);
 
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, []);
-
   return (
     <ExhibitionContainer>
       <MainCard

--- a/src/pages/Exhibition.tsx
+++ b/src/pages/Exhibition.tsx
@@ -13,8 +13,10 @@ import ReviewWrapper from "../components/ReviewWrapper";
 const Exhibition = () => {
   const params = useParams();
   const [exhbDetail, setExhbDetail] = useState<ExhibitionRes>();
+  const [state, setState] = useState("info");
   const navigate = useNavigate();
   const id = Number(params.id);
+
   const getExhbDetail = useCallback(async () => {
     try {
       const res: AxiosResponse<ExhibitionRes> = await exhbApi(id);
@@ -35,7 +37,10 @@ const Exhibition = () => {
     getExhbDetail();
   }, [getExhbDetail]);
 
-  const [state, setState] = useState("info");
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   return (
     <ExhibitionContainer>
       <MainCard


### PR DESCRIPTION
전시회 목록에서 전시회 카드를 클릭하여 상세페이지에 들어가면 이전 페이지의 스크롤이 유지가 되어서
스크롤을 최상단으로 끌어올리는 컴포넌트를 추가했습니다.

전시회 상세페이지 뿐만 아니라 메인페이지에서 전시회 자세히 보기를 클릭해도 스크롤이 맨 위로 안올라가서,
아예 pathname이 바뀔때마다 스크롤을 위로 끌어올리도록 컴포넌트를 만들었습니다.
파일 위치는 src - component - ScrollTop.tsx 입니다

+) 처음엔 전시회 상세페이지에 useEffect로 렌더링될 때 맨 위로 끌어올리는 코드로 추가했다가 ScrollTop컴포넌트 추가한거라,
작업하면서 useState가 아래쪽에 따로 떨어져있는 코드 발견하고 위쪽으로 올렸습니다.