### PR TITLE
Design: 메이트 모집글 상세페이지 썸네일 object-fit:cover속성 추가

### DIFF
--- a/src/components/mate/ExhbCard.tsx
+++ b/src/components/mate/ExhbCard.tsx
@@ -58,6 +58,7 @@ const ExhbCardContainer = styled.div`
 const Thumbnail = styled.img`
   width: 175px;
   height: inherit;
+  object-fit: cover;
 `;
 
 const InfoContainer = styled.div`


### PR DESCRIPTION
메이트글 상세페이지에서 썸네일이 썸네일박스 크기보다 크면 압축되어 보이는 현상이 있어
objext-fit:cover 속성을 추가했습니다