### PR TITLE
Fix: 블로그리뷰 상세페이지 버튼들 연결, css 수정

### DIFF
--- a/src/apis/blogReviewApis.tsx
+++ b/src/apis/blogReviewApis.tsx
@@ -14,7 +14,7 @@ const blogReviewApis = {
     return response;
   },
   readBlogReviews: async (
-    pageNo = 0,
+    pageNo = 1,
     orderType: "Recent" | "ViewCount" = "Recent"
   ) => {
     const response: AxiosResponse<BlogReviewResponse> = await apiInstance.get(

--- a/src/apis/exhibition.tsx
+++ b/src/apis/exhibition.tsx
@@ -78,7 +78,7 @@ export const exhbMateApi = async (id: number, pageNo: number) => {
 export interface ExhibitionRes {
   id: number;
   title: string;
-  status: string;
+  status: "현재 전시" | "예정 전시" | "지난 전시";
   type: string;
   space: string;
   adultPrice: number;

--- a/src/apis/exhibition.tsx
+++ b/src/apis/exhibition.tsx
@@ -78,7 +78,7 @@ export const exhbMateApi = async (id: number, pageNo: number) => {
 export interface ExhibitionRes {
   id: number;
   title: string;
-  status: "현재 전시" | "예정 전시" | "지난 전시";
+  status: string;
   type: string;
   space: string;
   adultPrice: number;

--- a/src/components/blogreview/container/BlogReviewDetailContainer.tsx
+++ b/src/components/blogreview/container/BlogReviewDetailContainer.tsx
@@ -46,7 +46,7 @@ const BlogReviewDetailContainer = ({
   if (isError) return <div>에러가 발생했습니다.</div>;
 
   return (
-    <Container>
+    <>
       <ButtonGroup>
         <div>
           <Button
@@ -106,28 +106,20 @@ const BlogReviewDetailContainer = ({
           }}
         />
       )}
-    </Container>
+    </>
   );
 };
 export default BlogReviewDetailContainer;
-
-const Container = styled.div`
-  width: 100%;
-  max-width: 1200px;
-`;
 
 const ButtonGroup = styled.div`
   display: flex;
   flex-flow: row wrap;
   justify-content: space-between;
   button {
-    margin-right: 10px;
     border: 1px solid ${theme.colors.greys40};
-    &.deleteBtn {
-      margin-right: 0;
-    }
   }
   & > div {
+    display: flex;
     gap: 10px;
   }
 `;

--- a/src/components/blogreview/container/BlogReviewDetailContainer.tsx
+++ b/src/components/blogreview/container/BlogReviewDetailContainer.tsx
@@ -2,11 +2,11 @@ import React from "react";
 import { useMutation, useQuery } from "react-query";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
-import { exhbApi } from "../../../apis/exhibition";
-import MainCard from "../../exhibition/MainCard";
-import Button from "../../atom/Button";
-import blogReviewApis from "../../../apis/blogReviewApis";
 import { theme } from "../../../styles/theme";
+import { exhbApi } from "../../../apis/exhibition";
+import blogReviewApis from "../../../apis/blogReviewApis";
+import Button from "../../atom/Button";
+import ExhbCard from "../../mate/ExhbCard";
 
 interface BlogReviewDetailContainerProps {
   id: number;
@@ -28,6 +28,7 @@ const BlogReviewDetailContainer = ({
     queryKey: ["blogCard"],
     queryFn: () => exhbApi(id),
   });
+  const exhbData = data?.data;
   const memeberId = localStorage.getItem("memberId") ?? "";
 
   const deleteReviewMutation = useMutation({
@@ -100,28 +101,26 @@ const BlogReviewDetailContainer = ({
           )}
         </div>
       </ButtonGroup>
-      {data ? (
-        <MainCard
-          id={data?.data.id}
-          posterUrl={data?.data.posterUrl}
-          title={data?.data.title}
-          duration={data?.data.duration}
-          place={data?.data.space}
-          charge={data?.data.adultPrice}
-          webLink={data?.data.webLink}
-          bookmarked={data?.data.bookmarked as boolean}
+      {exhbData && (
+        <ExhbCard
+          exhbData={{
+            exhibitionId: exhbData.id,
+            exhibitionTitle: exhbData.title,
+            exhibitionSpace: exhbData.space,
+            posterUrl: exhbData.posterUrl,
+            exhibitionDuration: exhbData.duration,
+            status: exhbData.status,
+          }}
         />
-      ) : null}
+      )}
     </Container>
   );
 };
 export default BlogReviewDetailContainer;
 
 const Container = styled.div`
-  position: relative;
   width: 100%;
   max-width: 1200px;
-  margin-inline: auto;
 `;
 
 const ButtonGroup = styled.div`

--- a/src/components/blogreview/container/BlogReviewDetailContainer.tsx
+++ b/src/components/blogreview/container/BlogReviewDetailContainer.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { useMutation, useQuery } from "react-query";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { exhbApi } from "../../../apis/exhibition";
 import MainCard from "../../exhibition/MainCard";
 import Button from "../../atom/Button";
 import blogReviewApis from "../../../apis/blogReviewApis";
+import { theme } from "../../../styles/theme";
 
 interface BlogReviewDetailContainerProps {
   id: number;
@@ -35,7 +36,8 @@ const BlogReviewDetailContainer = ({
 
   const handleDeleteReview = () => {
     deleteReviewMutation.mutate();
-    navigate("/");
+    alert("삭제되었습니다.");
+    navigate("/blogreview-list");
   };
 
   if (isLoading) return <div>...loading</div>;
@@ -46,13 +48,31 @@ const BlogReviewDetailContainer = ({
     <Container>
       <ButtonGroup>
         <div>
-          <Button variant="text" size="small">
+          <Button
+            variant="text"
+            size="small"
+            onClick={() => {
+              navigate("/blogreview-list");
+            }}
+          >
             목록
           </Button>
-          <Button variant="text" size="small">
+          <Button
+            variant="text"
+            size="small"
+            onClick={() => {
+              alert("준비 중인 기능입니다.");
+            }}
+          >
             이전글
           </Button>
-          <Button variant="text" size="small">
+          <Button
+            variant="text"
+            size="small"
+            onClick={() => {
+              alert("준비 중인 기능입니다.");
+            }}
+          >
             다음글
           </Button>
         </div>
@@ -94,7 +114,8 @@ export default BlogReviewDetailContainer;
 
 const Container = styled.div`
   position: relative;
-  width: 1240px;
+  width: 100%;
+  max-width: 1200px;
   margin-inline: auto;
 `;
 
@@ -103,6 +124,11 @@ const ButtonGroup = styled.div`
   flex-flow: row wrap;
   justify-content: space-between;
   align-items: center;
+  max-width: 1200px;
+  button {
+    margin-right: 10px;
+    border: 1px solid ${theme.colors.greys40};
+  }
   & > div {
     gap: 10px;
   }

--- a/src/components/blogreview/container/BlogReviewDetailContainer.tsx
+++ b/src/components/blogreview/container/BlogReviewDetailContainer.tsx
@@ -83,12 +83,7 @@ const BlogReviewDetailContainer = ({
               >
                 수정
               </Button>
-              <Button
-                onClick={handleDeleteReview}
-                variant="text"
-                size="small"
-                className="deleteBtn"
-              >
+              <Button onClick={handleDeleteReview} variant="text" size="small">
                 삭제
               </Button>
             </>

--- a/src/components/blogreview/container/BlogReviewDetailContainer.tsx
+++ b/src/components/blogreview/container/BlogReviewDetailContainer.tsx
@@ -88,7 +88,12 @@ const BlogReviewDetailContainer = ({
               >
                 수정
               </Button>
-              <Button onClick={handleDeleteReview} variant="text" size="small">
+              <Button
+                onClick={handleDeleteReview}
+                variant="text"
+                size="small"
+                className="deleteBtn"
+              >
                 삭제
               </Button>
             </>
@@ -123,11 +128,12 @@ const ButtonGroup = styled.div`
   display: flex;
   flex-flow: row wrap;
   justify-content: space-between;
-  align-items: center;
-  max-width: 1200px;
   button {
     margin-right: 10px;
     border: 1px solid ${theme.colors.greys40};
+    &.deleteBtn {
+      margin-right: 0;
+    }
   }
   & > div {
     gap: 10px;

--- a/src/components/blogreview/container/BlogReviewDetailContainer.tsx
+++ b/src/components/blogreview/container/BlogReviewDetailContainer.tsx
@@ -109,7 +109,6 @@ const BlogReviewDetailContainer = ({
             exhibitionSpace: exhbData.space,
             posterUrl: exhbData.posterUrl,
             exhibitionDuration: exhbData.duration,
-            status: exhbData.status,
           }}
         />
       )}

--- a/src/components/blogreview/container/BlogReviewDetailContainer.tsx
+++ b/src/components/blogreview/container/BlogReviewDetailContainer.tsx
@@ -52,27 +52,21 @@ const BlogReviewDetailContainer = ({
           <Button
             variant="text"
             size="small"
-            onClick={() => {
-              navigate("/blogreview-list");
-            }}
+            onClick={() => navigate("/blogreview-list")}
           >
             목록
           </Button>
           <Button
             variant="text"
             size="small"
-            onClick={() => {
-              alert("준비 중인 기능입니다.");
-            }}
+            onClick={() => alert("준비 중인 기능입니다.")}
           >
             이전글
           </Button>
           <Button
             variant="text"
             size="small"
-            onClick={() => {
-              alert("준비 중인 기능입니다.");
-            }}
+            onClick={() => alert("준비 중인 기능입니다.")}
           >
             다음글
           </Button>

--- a/src/components/blogreview/presentation/BlogReviewDetailPresentation.tsx
+++ b/src/components/blogreview/presentation/BlogReviewDetailPresentation.tsx
@@ -123,7 +123,6 @@ const BlogReviewDetailPresentation = ({
 export default BlogReviewDetailPresentation;
 
 const Container = styled.div`
-  width: 100%;
   padding: 30px;
   border: 1px solid ${theme.colors.greys40};
 `;

--- a/src/components/blogreview/presentation/BlogReviewDetailPresentation.tsx
+++ b/src/components/blogreview/presentation/BlogReviewDetailPresentation.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { theme } from "../../../styles/theme";
@@ -19,74 +19,114 @@ const BlogReviewDetailPresentation = ({
   imageInfo,
   memberInfo,
   likeCount,
+  likeStatus,
   bookmarkCount,
-}: BlogReviewDetailResponse) => (
-  <Container>
-    <DetailTitle>{title}</DetailTitle>
-    <Divider />
-    <DetailInformation>
-      <DetailDiv>
-        <span>관람일</span>
-        <p>{viewDate}</p>
-      </DetailDiv>
-      <DetailDiv>
-        <span>관람 시간</span>
-        <p>2022년 12월 14일</p>
-      </DetailDiv>
-      <DetailDiv>
-        <span>혼잡도</span>
-        <p>{congestion}</p>
-      </DetailDiv>
-      <DetailDiv>
-        <span>주차공간</span>
-        <p>{transportation}</p>
-      </DetailDiv>
-      <DetailDiv>
-        <span>재방문 의향</span>
-        <p>{revisit}</p>
-      </DetailDiv>
-    </DetailInformation>
-    <MainPart>
-      <StyledSWiper>
-        {imageInfo
-          ? imageInfo.map((each) => (
-              <SwiperSlide key={each.id}>
-                <img src={each.url} alt="전시회 상세조회 포스터" />
-              </SwiperSlide>
-            ))
-          : null}
-      </StyledSWiper>
-      <p>{content}</p>
-    </MainPart>
-    <UserInfo>
-      <img src={profileImage} alt="프로필 이미지" />
-      <h3>{memberInfo.nickname}</h3>
-      <DateandView>
-        <p>
-          <span>작성일</span> {createdAt}
-        </p>
-        <p>
-          <span>조회수</span> {viewCount}
-        </p>
-      </DateandView>
-    </UserInfo>
-    <ButtonGroup>
-      <Button size="small" variant="text" type="button">
-        유익해요 {likeCount}
-      </Button>
-      <Button size="small" variant="text" type="button">
-        저장하기 {bookmarkCount}
-      </Button>
-    </ButtonGroup>
-  </Container>
-);
+  bookmarkStatus,
+}: BlogReviewDetailResponse) => {
+  const token = localStorage.getItem("accessToken");
+
+  // 유익해요, 북마크 버튼 클릭해서 저장되면 그에 따라 디자인 변경되도록 했습니다.
+  // api만 연결하시면 됩니다.
+
+  // 유익해요 버튼 클릭 함수_박예선_23.02.07
+  const clickLikeBtn = () => {
+    if (!token) {
+      alert("로그인이 필요한 기능입니다.");
+    }
+    // 블로그리뷰 좋아요 api 붙이셔야합니다. 필요하시면 수정하셔도 됩니다 - 예선
+    // 블로그리뷰 좋아요 api 성공하면 다시 정보 받아오기
+    // -> 그래야 likeCount, likeStatus 반영됨
+  };
+
+  // 북마크 버튼 클릭 함수_박예선_23.02.07
+  const clickBookmarkBtn = () => {
+    if (!token) {
+      alert("로그인이 필요한 기능입니다.");
+    }
+    // 블로그리뷰 북마크 api 붙이셔야합니다. 필요하시면 수정하셔도 됩니다 - 예선
+    // 블로그리뷰 북마크 api 성공하면 다시 정보 받아오기
+    // -> 그래야 bookmarkCount, bookmarkStatus 반영됨
+  };
+
+  return (
+    <Container>
+      <DetailTitle>{title}</DetailTitle>
+      <Divider />
+      <DetailInformation>
+        <DetailDiv>
+          <span>관람일</span>
+          <p>{viewDate}</p>
+        </DetailDiv>
+        <DetailDiv>
+          <span>관람 시간</span>
+          <p>{time} 사이</p>
+        </DetailDiv>
+        <DetailDiv>
+          <span>혼잡도</span>
+          <p>{congestion}</p>
+        </DetailDiv>
+        <DetailDiv>
+          <span>주차공간</span>
+          <p>{transportation}</p>
+        </DetailDiv>
+        <DetailDiv>
+          <span>재방문 의향</span>
+          <p>{revisit}</p>
+        </DetailDiv>
+      </DetailInformation>
+      <MainPart>
+        <StyledSWiper>
+          {imageInfo
+            ? imageInfo.map((each) => (
+                <SwiperSlide key={each.id}>
+                  <img src={each.url} alt="전시회 상세조회 포스터" />
+                </SwiperSlide>
+              ))
+            : null}
+        </StyledSWiper>
+        <p>{content}</p>
+      </MainPart>
+      <UserInfo>
+        <img src={profileImage} alt="프로필 이미지" />
+        <h3>{memberInfo.nickname}</h3>
+        <DateAndView>
+          <p>
+            <span>작성일</span> {createdAt}
+          </p>
+          <p>
+            <span>조회수</span> {viewCount}
+          </p>
+        </DateAndView>
+      </UserInfo>
+      <ButtonGroup>
+        <Button
+          size="small"
+          variant={likeStatus ? "primary" : "text"}
+          type="button"
+          onClick={clickLikeBtn}
+        >
+          유익해요 {likeCount}
+        </Button>
+        <Button
+          size="small"
+          variant={bookmarkStatus ? "primary" : "text"}
+          type="button"
+          onClick={clickBookmarkBtn}
+        >
+          {bookmarkStatus ? "저장됨" : "저장하기"} {bookmarkCount}
+        </Button>
+      </ButtonGroup>
+    </Container>
+  );
+};
 
 export default BlogReviewDetailPresentation;
 
 const Container = styled.div`
-  width: 1240px;
+  width: 100%;
   padding: 30px;
   margin-inline: auto;
+  border: 1px solid ${theme.colors.greys40};
 `;
 
 const DetailTitle = styled.h2`
@@ -101,25 +141,25 @@ const Divider = styled.div`
 `;
 
 const DetailInformation = styled.div`
-  display: grid;
-  grid-auto-flow: column;
+  display: flex;
   gap: 30px;
+  margin-bottom: 50px;
   font-weight: 500;
   font-size: 12px;
   color: ${theme.colors.greys80};
-  margin-bottom: 50px;
 `;
 
 const DetailDiv = styled.div`
   display: flex;
-  justify-content: center;
   align-items: center;
   gap: 10px;
+  font-size: 14px;
   & span {
     padding: 2px 16px;
     border-radius: 30px;
     background-color: ${theme.colors.primry60};
     color: ${theme.colors.white100};
+    line-height: 20px;
   }
 `;
 
@@ -143,7 +183,7 @@ const UserInfo = styled.div`
   margin-bottom: 50px;
 `;
 
-const DateandView = styled.div`
+const DateAndView = styled.div`
   display: flex;
   color: ${theme.colors.greys90};
   gap: 20px;
@@ -160,6 +200,7 @@ const DateandView = styled.div`
     font-size: 12px;
     & > span {
       color: ${theme.colors.greys60};
+      margin-right: 4px;
     }
   }
 `;
@@ -168,4 +209,7 @@ const ButtonGroup = styled.div`
   display: flex;
   justify-content: center;
   gap: 30px;
+  button {
+    border: 1px solid ${theme.colors.greys40};
+  }
 `;

--- a/src/components/blogreview/presentation/BlogReviewDetailPresentation.tsx
+++ b/src/components/blogreview/presentation/BlogReviewDetailPresentation.tsx
@@ -125,7 +125,6 @@ export default BlogReviewDetailPresentation;
 const Container = styled.div`
   width: 100%;
   padding: 30px;
-  margin-inline: auto;
   border: 1px solid ${theme.colors.greys40};
 `;
 
@@ -142,6 +141,7 @@ const Divider = styled.div`
 
 const DetailInformation = styled.div`
   display: flex;
+  flex-wrap: wrap;
   gap: 30px;
   margin-bottom: 50px;
   font-weight: 500;

--- a/src/components/mate/ExhbCard.tsx
+++ b/src/components/mate/ExhbCard.tsx
@@ -10,7 +10,6 @@ interface ExhbCardType {
     exhibitionSpace: string;
     posterUrl: string;
     exhibitionDuration: string; // yyyy-mm-dd ~ yyyy-mm-dd
-    status: "현재 전시" | "예정 전시" | "지난 전시";
   };
 }
 

--- a/src/components/mate/ExhbCard.tsx
+++ b/src/components/mate/ExhbCard.tsx
@@ -53,6 +53,9 @@ const ExhbCardContainer = styled.div`
   margin: 14px 0 30px;
   border: 1px solid ${theme.colors.greys40};
   cursor: pointer;
+  .flex {
+    display: flex;
+  }
 `;
 
 const Thumbnail = styled.img`

--- a/src/pages/BlogReview.tsx
+++ b/src/pages/BlogReview.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { useQuery } from "react-query";
@@ -14,7 +14,7 @@ const BlogReview = () => {
   const navigate = useNavigate();
   const [pages, setPages] = useState({
     started: 0,
-    selected: 0,
+    selected: 1,
   });
   const [orderType, setOrderType] = useState<"Recent" | "ViewCount">("Recent");
   const [inputLength, setInputLength] = useState(0);

--- a/src/pages/BlogReview.tsx
+++ b/src/pages/BlogReview.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { useQuery } from "react-query";

--- a/src/pages/BlogReviewDetail.tsx
+++ b/src/pages/BlogReviewDetail.tsx
@@ -5,7 +5,6 @@ import styled from "styled-components";
 import blogReviewApis from "../apis/blogReviewApis";
 import BlogReviewDetailPresentation from "../components/blogreview/presentation/BlogReviewDetailPresentation";
 import BlogReviewDetailContainer from "../components/blogreview/container/BlogReviewDetailContainer";
-import Button from "../components/atom/Button";
 
 interface LocationState {
   state: number;
@@ -65,18 +64,8 @@ const BlogReviewDetail = () => {
 export default BlogReviewDetail;
 
 const Container = styled.div`
-  width: 100dvw;
-  width: 100vw;
+  width: 83vw;
+  max-width: 1200px;
+  margin: 50px auto;
   text-align: center;
-  border-radius: 0px;
-`;
-
-const ButtonGroup = styled.div`
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: space-between;
-  align-items: center;
-  & > div {
-    gap: 10px;
-  }
 `;

--- a/src/pages/BlogReviewDetail.tsx
+++ b/src/pages/BlogReviewDetail.tsx
@@ -35,7 +35,7 @@ const BlogReviewDetail = () => {
         blogReviewId={data?.id as number}
       />
       <div>
-        {data ? (
+        {data && (
           <BlogReviewDetailPresentation
             id={data.id}
             title={data.title}
@@ -55,7 +55,7 @@ const BlogReviewDetail = () => {
             imageInfo={data.imageInfo}
             exhibitionInfo={data.exhibitionInfo}
           />
-        ) : null}
+        )}
       </div>
     </Container>
   );
@@ -67,5 +67,4 @@ const Container = styled.div`
   width: 83vw;
   max-width: 1200px;
   margin: 50px auto;
-  text-align: center;
 `;


### PR DESCRIPTION
1. 버튼들 기능 연결, 디자인 수정했습니다.
  -1) 목록 - 클릭하면 전시리뷰 목록으로 이동
  -2) 이전글, 다음글 - 클릭하면 일단 '준비 중인 기능입니다.' alert실행
  -3) 삭제 - 기존에는 삭제버튼 클릭하면 삭제 후 바로 메인페이지로 이동하게 구현되어있었는데, alert으로 삭제됨 알려주고 전시리뷰 목록페이지로 이동하도록 수정 
  -4) 유익해요 - onClick함수 연결, boolean 값에 따라 디자인 변경되도록 구현함.
  -5) 북마크 - onClick함수 연결, boolean 값에 따라 디자인, 문구(저장됨/저장하기) 변경되도록 구현함.
  -5-1) ‼️ 4, 5번 항목은 api 연결은 안해두어서 그 부분은 동규님이 하셔야합니다.
  -6) 모든 버튼들에 테두리가 없어서 추가, 버튼사이 간격도 추가

2. 블로그리뷰 상세페이지의 전시회 정보 카드를 메이트글 상세페이지의 전시회 정보 카드를 재사용하는 것으로 교체.
    - 기존에는 전시회 상세페이지의 카드를 그대로 가져오셨습니다. 근데 크기나 디자인(배경색, 썸네일크기, 좋아요나 공유버튼 없는 것)이 피그마와 달라서 찾아보니 메이트모집글의 전시회카드와 디자인이 동일한 것을 확인했고, 교체했습니다.
    -> 2/7 기획/디자인 회의페이지를 보니 이것도 변경필요하더라구요 근데 일단은 급한건 아니니 요걸로 머지해두면 좋을 것 같아요

3. 블로그 리뷰 상세페이지(+ 자식컴포넌트들)의 넓이가 잘못 설정되어있어 변경.

4. 페이지 시작번호 1로 수정
    - ‼️ 이 부분은 변경될 수 있습니다. 작업하다가 갑자기 데이터가 안불러와져서 이유를 찾다보니 페이지를 1로 설정하면 되길래 일단 그렇게 했습니다. 백엔드 담당자분이 변경하신건지 확실히 전달을 못받아서 확실하게 답변받고 머지하겠습니다
  
5. 전체적인 넓이, max-width 수정
    - 피그마와 다르게 구성되어있는 부분이 있어 수정했습니다. 최대넓이 1200, 피그마기준 width : 83vw 입니다

기타 부연설명 필요한 부분은 코멘트로 달겠습니다
