### PR TITLE
Design: 전시회목록 페이지 레이아웃 수정, padding 피그마 추가된 부분 반영

### DIFF
--- a/src/components/exhibitionList/ExhbCardList.tsx
+++ b/src/components/exhibitionList/ExhbCardList.tsx
@@ -43,7 +43,7 @@ export default ExhbCardList;
 const CardListContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
-  width: inherit;
+  width: 100%;
   max-width: 1440px;
 `;
 

--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -95,7 +95,7 @@ const FiltersContainer = styled.div`
   display: flex;
   align-items: center;
   flex-direction: column;
-  width: inherit;
+  width: 100%;
   margin-bottom: 30px;
   .status-filter {
     width: 300px;

--- a/src/pages/ExhibitionList.tsx
+++ b/src/pages/ExhibitionList.tsx
@@ -67,6 +67,7 @@ const ExhibitionListContainer = styled.div`
   width: 100vw;
   max-width: 1440px;
   margin: auto;
+  padding: 40px;
   font-size: 14px;
   h1 {
     margin: 50px 0;
@@ -86,5 +87,11 @@ const ExhibitionListContainer = styled.div`
   }
   .none {
     display: none;
+  }
+  @media (max-width: 1280px) {
+    padding: 20px;
+  }
+  @media (max-width: 1064px) {
+    padding: 16px;
   }
 `;


### PR DESCRIPTION
1. 전시회 목록 필터들과 카드리스트가 화면 넓이만큼 꽉차보이는 부분 수정
2. 피그마에 화면 넓이 별 padding 추가해주셔서 반영

exbhCardList는 마이페이지에도 사용되는 컴포넌트지만 레이아웃 깨지는 부분 없는 것 확인했습니다