### PR TITLE
Fix: 메이트 작성/수정 페이지 취소버튼 시 모달 수정, 디자인 수정

### DIFF
--- a/src/pages/MateWrite.tsx
+++ b/src/pages/MateWrite.tsx
@@ -367,7 +367,7 @@ const MateWrite = () => {
           </div>
         </Section>
         <Section>
-          <SubTitle text="메이트 설명글" />
+          <SubTitle text="본문 내용" />
           <Editor>
             <Editor.TextInputArea
               value={content}

--- a/src/pages/MateWrite.tsx
+++ b/src/pages/MateWrite.tsx
@@ -395,17 +395,20 @@ const MateWrite = () => {
         >
           취소하기
         </Button>
-        {openCancleModal && (
+        <Modal
+          open={openCancleModal}
+          handleModal={() => setOpenCancleModal(!openCancleModal)}
+        >
           <SimpleDialog
-            message={`${mateId ? "수정" : "등록"}을 취소하시겠습니까?`}
-            cancelMessage="계속하기"
-            confirmMessage="확인"
+            message={`${mateId ? "수정" : "작성"}을 취소하시겠습니까?`}
+            cancelMessage={`계속 ${mateId ? "수정" : "작성"}하기`}
+            confirmMessage={`${mateId ? "수정" : "작성"} 취소하기`}
             clickCancleBtn={() => setOpenCancleModal(false)}
             clickConfirmBtn={() => {
               navigate("/mate-list", { replace: true });
             }}
           />
-        )}
+        </Modal>
         <Button
           variant="primary"
           size="small"
@@ -568,6 +571,7 @@ const BtnContainer = styled.div`
   text-align: center;
   button {
     width: 153px;
+    padding: 10px 0;
     :nth-child(1) {
       margin-right: 30px;
     }


### PR DESCRIPTION
1. 취소하기 버튼 클릭 시 모달 뒤로 어두운 뒷배경이 안나오는 부분 수정-> 모달컴포넌트 안에 집어넣지 않아서 그런거라 모달컴포넌트를 활용해 수정
2. 취소하기 버튼 클릭 시 나오는 문구 협의된 대로 수정
3. 본문 내용 입력창 위 타이틀 본문 내용으로 수정