### PR TITLE
Fix: 회원가입 시 빈값이면 유효성검사하지 않도록 수정

### DIFF
--- a/src/components/signUp/AdminOnly.tsx
+++ b/src/components/signUp/AdminOnly.tsx
@@ -10,12 +10,12 @@ interface AdminOnlyType {
   handleInput: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-// 관리자용 회원가입 UI 컴포넌트_박예선_23.01.08
+// 관리자용 회원가입 UI 컴포넌트_박예선_23.02.07
 const AdminOnly = (props: AdminOnlyType) => {
   const { infos, valids, setValids, isOnly, setIsOnly, handleInput } = props;
   const [timer, setTimer] = useState<ReturnType<typeof setTimeout>>();
 
-  // 관리자번호 유효성검사_박예선_23.01.09
+  // 관리자번호 유효성검사_박예선_23.02.07
   const handleAdiminNoValid = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
     const rAdminNo = /^[0-9]+$/;
@@ -27,14 +27,14 @@ const AdminOnly = (props: AdminOnlyType) => {
       const isAdminNoValid = rAdminNo.test(value);
       setValids({
         ...valids,
-        adminNo: isAdminNoValid,
+        adminNo: value === "" ? null : isAdminNoValid,
       });
     }, 800);
     setTimer(newTimer);
     setIsOnly({ ...isOnly, adminNo: null });
   };
 
-  // 관리자본명 유효성검사_박예선_23.01.09
+  // 관리자본명 유효성검사_박예선_23.02.07
   const handleNameValid = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
     const rName = /^[가-힣]{2,10}$/;
@@ -46,7 +46,7 @@ const AdminOnly = (props: AdminOnlyType) => {
       const isNameValid = rName.test(value);
       setValids({
         ...valids,
-        name: isNameValid,
+        name: value === "" ? null : isNameValid,
       });
     }, 800);
     setTimer(newTimer);
@@ -59,7 +59,7 @@ const AdminOnly = (props: AdminOnlyType) => {
         <input
           type="password"
           name="adminNo"
-          placeholder="회사에서 제공한 개인 고유 번호를 입력해주세요"
+          placeholder="개인 고유 번호를 입력해주세요"
           value={infos.adminNo === 0 ? "" : infos.adminNo}
           onChange={(e) => {
             handleInput(e);

--- a/src/components/signUp/CommonOnly.tsx
+++ b/src/components/signUp/CommonOnly.tsx
@@ -40,7 +40,7 @@ const CommonOnly = (props: CommonOnlyType) => {
     }
   };
 
-  // 닉네임 유효성검사_박예선_23.01.09
+  // 닉네임 유효성검사_박예선_23.02.07
   const handleNicknameValid = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
     const rNickname = /^[가-힣|a-z|A-Z|0-9|]{2,10}$/;
@@ -52,7 +52,7 @@ const CommonOnly = (props: CommonOnlyType) => {
       const isNicknameValid = rNickname.test(value);
       setValids({
         ...valids,
-        nickname: isNicknameValid,
+        nickname: value === "" ? null : isNicknameValid,
       });
     }, 800);
     setTimer(newTimer);

--- a/src/components/signUp/EmailAndPw.tsx
+++ b/src/components/signUp/EmailAndPw.tsx
@@ -14,7 +14,7 @@ const EmailAndPw = (props: EmailAndPwType) => {
   const { infos, valids, setValids, isOnly, handleInput } = props;
   const [timer, setTimer] = useState<ReturnType<typeof setTimeout>>();
 
-  // 이메일 유효성 상태관리_박예선_23.01.09
+  // 이메일 유효성 상태관리_박예선_23.02.07
   const handleEmailValid = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
     const rEmail = /^[a-zA-Z0-9+.]+@[a-z]+\.[a-z]{2,3}$/;
@@ -26,13 +26,13 @@ const EmailAndPw = (props: EmailAndPwType) => {
       const isEmailValid = rEmail.test(value);
       setValids({
         ...valids,
-        email: isEmailValid,
+        email: value === "" ? null : isEmailValid,
       });
     }, 800);
     setTimer(newTimer);
   };
 
-  // 비밀번호 유효성 상태관리_박예선_23.01.09
+  // 비밀번호 유효성 상태관리_박예선_23.02.07
   const handlePwValid = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
     const rPassword =
@@ -46,14 +46,14 @@ const EmailAndPw = (props: EmailAndPwType) => {
       const isPwCheckValid = infos.pwCheck === value;
       setValids({
         ...valids,
-        password: isPwValid,
-        pwCheck: isPwCheckValid,
+        password: value === "" ? null : isPwValid,
+        pwCheck: infos.pwCheck ? isPwCheckValid : null,
       });
     }, 800);
     setTimer(newTimer);
   };
 
-  // 비밀번호 확인 상태관리_박예선_23.01.08
+  // 비밀번호 확인 상태관리_박예선_23.02.07
   const handlePwCheckValid = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
     if (timer) {
@@ -61,7 +61,10 @@ const EmailAndPw = (props: EmailAndPwType) => {
     }
     const newTimer = setTimeout(() => {
       const isPwCheckValid = infos.password === value;
-      setValids({ ...valids, pwCheck: isPwCheckValid });
+      setValids({
+        ...valids,
+        pwCheck: value === "" ? null : isPwCheckValid,
+      });
     }, 800);
     setTimer(newTimer);
   };


### PR DESCRIPTION
일반/관리자 회원가입 시 인풋창에 값을 입력했다가 빈칸으로 삭제해도 오류메세지가 떠서, 빈칸이면 오류가 뜨지 않고 원상태가 되도록 수정했습니다.