### PR TITLE
Fix: 메이트글 수정시 기존 선택된 전시회가 나오지 않는 버그, 액세스토큰만료 응답 받아도 로직실행이 안되는 버그 수정

### DIFF
--- a/src/pages/MateWrite.tsx
+++ b/src/pages/MateWrite.tsx
@@ -135,16 +135,15 @@ const MateWrite = () => {
             mateId
           );
           alert(res.data);
-          navigate(-1);
         } catch {
           errorAlert();
-          navigate("/mate-list");
         }
+        navigate(-1);
       }
       if (typeof errorRes !== "object") return;
       const { errorMsg } = errorRes;
       alert(errorMsg);
-      navigate("/mate-list");
+      navigate(-1);
     }
   };
 

--- a/src/pages/MateWrite.tsx
+++ b/src/pages/MateWrite.tsx
@@ -19,7 +19,7 @@ import isApiError, { errorAlert } from "../utils/isApiError";
 import ExhibitionChoice from "../components/ExhibitionChoice";
 import Modal from "../Modal";
 
-// 메이트글 작성/수정 페이지_박예선_23.02.02
+// 메이트글 작성/수정 페이지_박예선_23.02.08
 const MateWrite = () => {
   const refreshTokenApi = useRefreshTokenApi();
   const location = useLocation();
@@ -46,7 +46,7 @@ const MateWrite = () => {
   });
   const [selectedDate, setSelectedDate] = useState("");
   const [openExhbModal, setOpenExhbModal] = useState(false);
-  const [selectedExhb, setSelectedExhb] = useState({
+  const [exhbData, setExhbData] = useState({
     thumbnail: "",
     status: "",
     title: "",
@@ -76,11 +76,12 @@ const MateWrite = () => {
     }
   }, [memberId, navigate]);
 
-  // 기존 메이트글 정보 조회 api 호출_박예선_23.01.28
+  // 기존 메이트글 정보 조회 api 호출_박예선_23.02.08
   const getMate = useCallback(async () => {
     try {
       const res: AxiosResponse<MateRes> = await mateApi(mateId, memberId);
       const { data } = res;
+      const { exhibition } = data;
       if (memberId !== data.member.memberId) {
         alert("본인이 작성한 메이트글만 수정할 수 있습니다.");
         navigate("/mate-list");
@@ -96,6 +97,12 @@ const MateWrite = () => {
         contact: data.contact,
         exhibitionId: data.exhibition.exhibitionId,
       });
+      setExhbData({
+        thumbnail: exhibition.posterUrl,
+        status: exhibition.status,
+        title: exhibition.exhibitionTitle,
+        duration: exhibition.exhibitionDuration,
+      });
       if (data.mateAge !== "연령 무관")
         setAgeRange({
           minimum: data.mateAge.split(" ~ ")[0],
@@ -107,7 +114,7 @@ const MateWrite = () => {
     }
   }, [mateId, memberId, navigate]);
 
-  // 메이트글 작성/수정 api 호출_박예선_23.01.29
+  // 메이트글 작성/수정 api 호출_박예선_23.02.08
   const clickApplyBtn = async (type: "post" | "put") => {
     try {
       const res: AxiosResponse<MateWriteRes> = await mateWriteApi(
@@ -120,14 +127,19 @@ const MateWrite = () => {
     } catch (err) {
       const errorRes = isApiError(err);
       if (errorRes === "accessToken 만료") {
-        refreshTokenApi();
-        const res: AxiosResponse<MateWriteRes> = await mateWriteApi(
-          type,
-          writeData,
-          mateId
-        );
-        alert(res.data);
-        navigate(-1);
+        try {
+          refreshTokenApi();
+          const res: AxiosResponse<MateWriteRes> = await mateWriteApi(
+            type,
+            writeData,
+            mateId
+          );
+          alert(res.data);
+          navigate(-1);
+        } catch {
+          errorAlert();
+          navigate("/mate-list");
+        }
       }
       if (typeof errorRes !== "object") return;
       const { errorMsg } = errorRes;
@@ -230,7 +242,7 @@ const MateWrite = () => {
       setWriteData({ ...writeData, availableDate: date });
   };
 
-  // 전시회 선택 함수_박예선_23.01.31
+  // 전시회 선택 함수_박예선_23.02.08
   const handleExhbModal = (
     url: string,
     id: number,
@@ -239,7 +251,7 @@ const MateWrite = () => {
     status: string
   ) => {
     setWriteData({ ...writeData, exhibitionId: id });
-    setSelectedExhb({
+    setExhbData({
       title,
       thumbnail: url,
       status,
@@ -321,14 +333,14 @@ const MateWrite = () => {
               {exhibitionId !== 0 && (
                 <img
                   className="thumbnail"
-                  src={selectedExhb.thumbnail}
+                  src={exhbData.thumbnail}
                   alt="선택된 전시회"
                 />
               )}
               {exhibitionId !== 0 && isThumbnailHovered && (
                 <ThumbnailHover>
                   <Button variant="primary" size="small" className="status">
-                    {selectedExhb.status}
+                    {exhbData.status}
                   </Button>
                   <button
                     type="button"
@@ -339,8 +351,8 @@ const MateWrite = () => {
                   >
                     X
                   </button>
-                  <div className="title">{selectedExhb.title}</div>
-                  <div className="duration">{selectedExhb.duration}</div>
+                  <div className="title">{exhbData.title}</div>
+                  <div className="duration">{exhbData.duration}</div>
                 </ThumbnailHover>
               )}
             </ExhbChoiceBtn>


### PR DESCRIPTION
1. 메이트글을 작성하고 수정페이지에 들어가면 선택했던 전시회의 정보가 나오지 않는 버그 수정했습니다.
2. 1번 사항 수정과정에서 액세스토큰만료된 상태로 수정버튼을 클릭했는데 구현했던 에러로직이 바로 실행되지 않고 저번 로그아웃클릭시처럼 한번 더 클릭해야 실행되는 버그를 발견하고, try catch문을 이용해 수정했습니다.
    이제 액세스토큰이 만료된 상태로 수정버튼을 클릭하면 바로 리프레시토큰 인증이 실행되고 그 인증이 성공되면 사용자 모르게 다시 수정요청이 가서 사용자입장에서 불편한 부분이 없게 됩니다
3. 메이트글 작성/수정 시 api요청에 실패 했을 때 단순히 mate-list로 navigate하는게 아니라 navigate(-1)을 해서 이전 페이지로 돌아가도록하고, 뒤로가기 버튼을 클릭해도 작성/수정페이지로 돌아가지 못하도록 했습니다.