### PR TITLE
Fix: 관리자는 메이트글 작성/수정  할 수 없도록 버튼 숨김, 작성/수정 페이지 접속 시 리다이렉트

### DIFF
--- a/src/components/mate/MateListFilter.tsx
+++ b/src/components/mate/MateListFilter.tsx
@@ -9,10 +9,11 @@ interface MateListFilterType {
   setMateStatusFilter: React.Dispatch<React.SetStateAction<MateStatusType>>;
 }
 
-// 메이트목록 상단 필터, 검색 컴포넌트_박예선_23.02.01
+// 메이트목록 상단 필터, 검색 컴포넌트_박예선_23.02.08
 const MateListFilter = (props: MateListFilterType) => {
   const { setMateStatusFilter } = props;
   const navigate = useNavigate();
+  const isAdmin = localStorage.getItem("authority") === "ROLE_ADMIN";
 
   // 필터 조건 핸들 함수_박예선_23.02.01
   const handleFilters = (e: React.MouseEvent<HTMLLIElement, MouseEvent>) => {
@@ -43,20 +44,22 @@ const MateListFilter = (props: MateListFilterType) => {
             if (e.key === "Enter") alert("준비 중인 기능입니다.");
           }}
         />
-        <Button
-          variant="primary"
-          size="small"
-          className="mate-write-btn"
-          onClick={() => {
-            if (!localStorage.getItem("accessToken")) {
-              alert("로그인이 필요합니다.");
-              return;
-            }
-            navigate("/mate-write");
-          }}
-        >
-          메이트 모집하기
-        </Button>
+        {!isAdmin && (
+          <Button
+            variant="primary"
+            size="small"
+            className="mate-write-btn"
+            onClick={() => {
+              if (!localStorage.getItem("accessToken")) {
+                alert("로그인이 필요합니다.");
+                return;
+              }
+              navigate("/mate-write");
+            }}
+          >
+            메이트 모집하기
+          </Button>
+        )}
       </div>
     </FilterContainer>
   );

--- a/src/pages/MateWrite.tsx
+++ b/src/pages/MateWrite.tsx
@@ -66,13 +66,16 @@ const MateWrite = () => {
     exhibitionId,
   } = writeData;
 
-  // 전시회 선택 모달 연결하기
-
-  // 토큰 없을 때 접속하면 로그인페이지로 리다이렉트_박예선_23.01.29
+  // 로그인을 안했거나, 관리자일 경우 리다이렉트_박예선_23.02.08
   useEffect(() => {
     if (!memberId) {
       alert("로그인이 필요한 기능입니다.");
       navigate("/login");
+      return;
+    }
+    if (localStorage.getItem("authority") === "ROLE_ADMIN") {
+      alert("관리자는 메이트글을 작성/수정할 수 없습니다.");
+      navigate("/mate-list", { replace: true });
     }
   }, [memberId, navigate]);
 


### PR DESCRIPTION
백엔드분들과 협의해 관리자는 메이트글 작성/수정을 할 수 없게 수정했습니다.

1. 일반 사용자(로그인 여부 관계없이)에게만 메이트글 작성/수정 버튼을 표시
2. url로 작성/수정 페이지를 접속하면 리다이렉트

