### PR TITLE
전시회 목록 피그마 수정사항 반영, 전시목록 검색창 준비 중입니다 알림창 추가, css 리팩토링

### DIFF
--- a/src/components/exhibitionList/ExhbCardList.tsx
+++ b/src/components/exhibitionList/ExhbCardList.tsx
@@ -54,7 +54,7 @@ const ExhibitionCard = styled.div<{
   width: ${(props) => (props.type === "exhbList" ? "23.43%" : "31.66%")};
   margin-right: ${(props) => (props.type === "exhbList" ? "2.093%" : "2.5%")};
   margin-bottom: ${(props) => (props.type === "exhbList" ? "2.093%" : "2.5%")};
-  padding-bottom: 42.99%;
+  aspect-ratio: 1/1.48;
   border: 2px solid ${theme.colors.greys40};
   border-radius: 33px;
   cursor: pointer;
@@ -76,7 +76,7 @@ const ExhibitionCard = styled.div<{
     transform: translate(-50%);
     align-items: center;
     width: 82.24%;
-    height: 24.5%;
+    height: 30%;
     text-decoration: none;
   }
 `;
@@ -84,14 +84,14 @@ const ExhibitionCard = styled.div<{
 const Thumbnail = styled.img`
   position: absolute;
   width: 100%;
-  height: 75.5%;
+  height: 70%;
   object-fit: cover;
 `;
 
 const Content = styled.div`
   position: relative;
   width: 100%;
-  height: 60.5%;
+  height: 60%;
 `;
 
 const ContentTop = styled.div`

--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -6,7 +6,7 @@ import Button from "../atom/Button";
 import Selectbox from "../atom/Selectbox";
 import { PagesState } from "../Pagination";
 
-// 전시글 목록 상단 필터 컴포넌트_박예선_23.02.01
+// 전시글 목록 상단 필터 컴포넌트_박예선_23.02.08
 const Filters = (props: FiltersType) => {
   const { setPages, selectedStatus, setSelectedStatus, setSelectedFilter } =
     props;
@@ -64,7 +64,13 @@ const Filters = (props: FiltersType) => {
             onClick={handleFilters}
           />
         </div>
-        <input placeholder="검색" className="search-input border" />
+        <SearchInput
+          placeholder="검색"
+          onClick={() => alert("준비 중인 기능입니다.")}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") alert("준비 중인 기능입니다.");
+          }}
+        />
       </div>
     </FiltersContainer>
   );
@@ -103,22 +109,21 @@ const FiltersContainer = styled.div`
     margin-bottom: 14px;
     font-size: 14px;
     button {
-      display: flex;
-      align-items: center;
       font-size: 14px;
-      cursor: pointer;
+      line-height: inherit;
       &.selected {
         color: ${theme.colors.greys100};
       }
     }
   }
   .filter-search-line {
+    flex-wrap: wrap;
+    gap: 10px;
     width: inherit;
     max-width: 1440px;
     padding-top: 14px;
     border-top: 1px solid ${(props) => props.theme.colors.greys40};
     border-radius: 0%;
-    input,
     button {
       height: 36px;
       font-size: 14px;
@@ -130,29 +135,19 @@ const FiltersContainer = styled.div`
         margin-right: 10px;
       }
     }
-    .apply-btn {
-      width: 66px;
-      padding: 0;
-      border-color: #6750a4;
-      background-color: #6750a4;
-      color: ${(props) => props.theme.colors.white100};
-      font-weight: 700;
-      &:active {
-        background-color: #483974;
-      }
-    }
   }
-  .search-input {
-    width: 277px;
-    padding-right: 54px;
-    background: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='11' cy='11' r='6' stroke='%239C9C9C' stroke-width='2'/%3E%3Cpath d='M16.2071 14.7929L15.5 14.0858L14.0858 15.5L14.7929 16.2071L16.2071 14.7929ZM18.2929 19.7071C18.6834 20.0976 19.3166 20.0976 19.7071 19.7071C20.0976 19.3166 20.0976 18.6834 19.7071 18.2929L18.2929 19.7071ZM14.7929 16.2071L18.2929 19.7071L19.7071 18.2929L16.2071 14.7929L14.7929 16.2071Z' fill='%239C9C9C'/%3E%3C/svg%3E%0A")
-      no-repeat;
-    background-position: right 25px center;
-    &::placeholder {
-      color: ${(props) => props.theme.colors.greys60};
-    }
-    &:hover {
-      cursor: text;
-    }
+`;
+
+const SearchInput = styled.input`
+  width: 277px;
+  height: 36px;
+  padding: 0 42px 0 20px;
+  border: 1px solid ${(props) => props.theme.colors.greys40};
+  background: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='11' cy='11' r='6' stroke='%239C9C9C' stroke-width='2'/%3E%3Cpath d='M16.2071 14.7929L15.5 14.0858L14.0858 15.5L14.7929 16.2071L16.2071 14.7929ZM18.2929 19.7071C18.6834 20.0976 19.3166 20.0976 19.7071 19.7071C20.0976 19.3166 20.0976 18.6834 19.7071 18.2929L18.2929 19.7071ZM14.7929 16.2071L18.2929 19.7071L19.7071 18.2929L16.2071 14.7929L14.7929 16.2071Z' fill='%239C9C9C'/%3E%3C/svg%3E%0A")
+    no-repeat;
+  background-position: right 14px center;
+  font-size: 14px;
+  &::placeholder {
+    color: ${(props) => props.theme.colors.greys60};
   }
 `;

--- a/src/pages/ExhibitionList.tsx
+++ b/src/pages/ExhibitionList.tsx
@@ -7,7 +7,7 @@ import Pagination from "../components/Pagination";
 import Filters, { StatusType } from "../components/exhibitionList/Filters";
 import ExhbCardList from "../components/exhibitionList/ExhbCardList";
 
-// 전시회 목록 페이지 컴포넌트_박예선_23.02.01
+// 전시회 목록 페이지 컴포넌트_박예선_23.02.08
 const ExhibitionList = () => {
   const [exhbList, setExhbList] = useState<Exhibition[]>([]);
   const [totalPage, setTotalPage] = useState<number>(0);
@@ -67,10 +67,10 @@ const ExhibitionListContainer = styled.div`
   width: 100vw;
   max-width: 1440px;
   margin: auto;
-  padding: 40px;
+  padding: 40px 40px 0;
   font-size: 14px;
   h1 {
-    margin: 50px 0;
+    margin-bottom: 50px;
     font-size: 28px;
     font-weight: 700;
   }


### PR DESCRIPTION
1. 전시회 카드 가로세로 비율 축소 요청이 있어서 수정했습니다
2. 피그마를 다시 보니 '전시회'라는 타이틀과 nav바 사이의 여백이 달라 수정했습니다(이밖에 자잘한 여백도 변경이 있어 수정됨)
3. 전시 목록 상단 우측 검색창 
   - 디자인적 수정사항은 검색아이콘이 조금 오른쪽으로 이동된 것 빼곤 없음
   - 클릭/엔터 시 준비중입니다 알림창 추가
   - 일반 css코드를 스타일드 컴포넌트로 수정
4. 사용하지 않는 css 클래스 코드 삭제(전에 지워야했는데 발견 못했던 부분)