### PR TITLE
Fix: 전시 리뷰 목록 레이아웃과 이미지 없으면 엑박뜨던 부분 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,11 +13,11 @@ import Mypage from "./pages/Mypage";
 import MateList from "./pages/MateList";
 import Mate from "./pages/Mate";
 import MateWrite from "./pages/MateWrite";
-import Footer from "./components/Footer";
-import BlogReview from "./pages/BlogReview";
+import BlogReviewList from "./pages/BlogReviewList";
 import BlogReviewWrite from "./pages/BlogReviewWrite";
 import BlogReviewUpdate from "./pages/BlogReviewModify";
 import BlogReviewDetail from "./pages/BlogReviewDetail";
+import Footer from "./components/Footer";
 
 const App = () => (
   <BrowserRouter>
@@ -40,11 +40,11 @@ const App = () => (
       <Route path="/mypage/:subpages" element={<Mypage />} />
       <Route path="/mate-list" element={<MateList />} />
       <Route path="/mate/:id" element={<Mate />} />
-      <Route path="/blogreview-list" element={<BlogReview />} />
+      <Route path="/mate-write" element={<MateWrite />} />
+      <Route path="/blogreview-list" element={<BlogReviewList />} />
       <Route path="/blogreview-write" element={<BlogReviewWrite />} />
       <Route path="/blogreview-edit" element={<BlogReviewUpdate />} />
       <Route path="/blogreview-detail" element={<BlogReviewDetail />} />
-      <Route path="/mate-write" element={<MateWrite />} />
     </Routes>
     <ReactQueryDevtools />
     <Footer />

--- a/src/components/blogReviewList/ReviewCard.tsx
+++ b/src/components/blogReviewList/ReviewCard.tsx
@@ -49,6 +49,13 @@ const Container = styled.div`
     border: 1px solid ${theme.colors.primry60};
     box-shadow: 0px 0px 20px rgba(56, 30, 114, 0.1);
     cursor: pointer;
+    h2 {
+      color: ${theme.colors.primry80};
+    }
+    p,
+    div > div {
+      color: ${theme.colors.primry60};
+    }
   }
 `;
 

--- a/src/components/blogReviewList/ReviewCard.tsx
+++ b/src/components/blogReviewList/ReviewCard.tsx
@@ -63,10 +63,15 @@ const ThumbnailContainer = styled.div`
   position: relative;
   width: inherit;
   height: 62%;
+  border-bottom: 1px solid ${theme.colors.greys40};
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
   img {
     width: 100%;
     height: 100%;
     object-fit: cover;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
   }
   .default-thumbnail {
     position: absolute;

--- a/src/components/blogReviewList/ReviewCard.tsx
+++ b/src/components/blogReviewList/ReviewCard.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
-import { theme } from "../../../styles/theme";
-import logo from "../../../assets/icons/logo.svg";
-import { BlogReviewInfo } from "../../../types/blogReview";
+import { theme } from "../../styles/theme";
+import logo from "../../assets/icons/logo.svg";
+import { BlogReviewInfo } from "../../types/blogReview";
 
-const BlogReviewCard = ({
+const ReviewCard = ({
   id,
   title,
   writer,
@@ -40,7 +40,7 @@ const BlogReviewCard = ({
   );
 };
 
-export default BlogReviewCard;
+export default ReviewCard;
 
 const Container = styled.div`
   border: 1px solid ${theme.colors.greys60};

--- a/src/components/blogReviewList/ReviewCardList.tsx
+++ b/src/components/blogReviewList/ReviewCardList.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 import styled from "styled-components";
-import { BlogReviewResponse } from "../../../types/blogReview";
-import NoList from "../../NoList";
-import BlogReviewCard from "../presentation/BlogReviewCard";
+import { BlogReviewResponse } from "../../types/blogReview";
+import NoList from "../NoList";
+import ReviewCard from "./ReviewCard";
 
 const ReviewCardList = ({ blogInfo }: BlogReviewResponse) => (
   <ReviewCardListContainer>
     {blogInfo.length === 0 && <NoList notice="작성된 리뷰가 없습니다." />}
     {blogInfo.length !== 0 &&
       blogInfo.map((each) => (
-        <BlogReviewCard
+        <ReviewCard
           key={each.id}
           id={each.id}
           title={each.title}

--- a/src/components/blogreview/container/BlogReviewReadContainer.tsx
+++ b/src/components/blogreview/container/BlogReviewReadContainer.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { OnelineReviewReadType } from "../../../types/oneLineReview";
 import ReviewSearchBar from "../../reviewCommon/ReviewSearchBar";
 import Pagination from "../../Pagination";
-import BlogReviewCard from "../presentation/BlogReviewCard";
+import BlogReviewCard from "../../blogReviewList/ReviewCard";
 import blogReviewApis from "../../../apis/blogReviewApis";
 import { BlogReviewResponse } from "../../../types/blogReview";
 

--- a/src/components/blogreview/container/ReviewCardList.tsx
+++ b/src/components/blogreview/container/ReviewCardList.tsx
@@ -5,7 +5,7 @@ import blogReviewApis from "../../../apis/blogReviewApis";
 import { BlogReviewInfo, BlogReviewResponse } from "../../../types/blogReview";
 import BlogReviewCard from "../presentation/BlogReviewCard";
 
-const BlogReviewListWrapper = ({ blogInfo }: BlogReviewResponse) => (
+const ReviewCardList = ({ blogInfo }: BlogReviewResponse) => (
   <Container>
     <CardWrapper>
       {blogInfo &&
@@ -24,7 +24,7 @@ const BlogReviewListWrapper = ({ blogInfo }: BlogReviewResponse) => (
   </Container>
 );
 
-export default BlogReviewListWrapper;
+export default ReviewCardList;
 
 const Container = styled.div`
   margin-inline: auto;

--- a/src/components/blogreview/container/ReviewCardList.tsx
+++ b/src/components/blogreview/container/ReviewCardList.tsx
@@ -1,36 +1,30 @@
 import React from "react";
-import { useQuery } from "react-query";
 import styled from "styled-components";
-import blogReviewApis from "../../../apis/blogReviewApis";
-import { BlogReviewInfo, BlogReviewResponse } from "../../../types/blogReview";
+import { BlogReviewResponse } from "../../../types/blogReview";
+import NoList from "../../NoList";
 import BlogReviewCard from "../presentation/BlogReviewCard";
 
 const ReviewCardList = ({ blogInfo }: BlogReviewResponse) => (
-  <Container>
-    <CardWrapper>
-      {blogInfo &&
-        blogInfo.map((each) => (
-          <BlogReviewCard
-            key={each.id}
-            id={each.id}
-            title={each.title}
-            writer={each.writer}
-            viewDate={each.viewDate}
-            viewCount={each.viewCount}
-            imageInfo={each.imageInfo}
-          />
-        ))}
-    </CardWrapper>
-  </Container>
+  <ReviewCardListContainer>
+    {blogInfo.length === 0 && <NoList notice="작성된 리뷰가 없습니다." />}
+    {blogInfo.length !== 0 &&
+      blogInfo.map((each) => (
+        <BlogReviewCard
+          key={each.id}
+          id={each.id}
+          title={each.title}
+          writer={each.writer}
+          viewDate={each.viewDate}
+          viewCount={each.viewCount}
+          imageInfo={each.imageInfo}
+        />
+      ))}
+  </ReviewCardListContainer>
 );
 
 export default ReviewCardList;
 
-const Container = styled.div`
-  margin-inline: auto;
-`;
-
-const CardWrapper = styled.div`
+const ReviewCardListContainer = styled.div`
   display: grid;
   /* grid-template-columns: repeat(auto-fill, minmax(250px, 380px)); */
   grid-template-columns: repeat(auto-fit, 380px);

--- a/src/components/blogreview/presentation/BlogReviewCard.tsx
+++ b/src/components/blogreview/presentation/BlogReviewCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { theme } from "../../../styles/theme";
@@ -15,10 +15,6 @@ const BlogReviewCard = ({
 }: BlogReviewInfo) => {
   const navigate = useNavigate();
   const imageUrl = imageInfo?.url;
-
-  useEffect(() => {
-    console.log(imageUrl);
-  }, [imageUrl]);
 
   return (
     <Container onClick={() => navigate("/blogreview-detail", { state: id })}>
@@ -49,6 +45,11 @@ export default BlogReviewCard;
 const Container = styled.div`
   border: 1px solid ${theme.colors.greys60};
   aspect-ratio: 1/1.05;
+  :hover {
+    border: 1px solid ${theme.colors.primry60};
+    box-shadow: 0px 0px 20px rgba(56, 30, 114, 0.1);
+    cursor: pointer;
+  }
 `;
 
 const ThumbnailContainer = styled.div`

--- a/src/components/blogreview/presentation/BlogReviewCard.tsx
+++ b/src/components/blogreview/presentation/BlogReviewCard.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { theme } from "../../../styles/theme";
+import logo from "../../../assets/icons/logo.svg";
 import { BlogReviewInfo } from "../../../types/blogReview";
 
 const BlogReviewCard = ({
@@ -13,21 +14,32 @@ const BlogReviewCard = ({
   imageInfo,
 }: BlogReviewInfo) => {
   const navigate = useNavigate();
-  const imageUrl = imageInfo?.url ?? null;
+  const imageUrl = imageInfo?.url;
+
+  useEffect(() => {
+    console.log(imageUrl);
+  }, [imageUrl]);
 
   return (
     <Container onClick={() => navigate("/blogreview-detail", { state: id })}>
-      <Image>
-        <img src={imageUrl ? imageInfo.url : ""} alt="블로그 리뷰 이미지" />
-      </Image>
-      <Review>
+      <ThumbnailContainer>
+        {imageUrl && <img src={imageInfo.url} alt="블로그 리뷰 사진" />}
+        {!imageUrl && (
+          <img
+            src={logo}
+            alt="블로그 리뷰 사진"
+            className="default-thumbnail"
+          />
+        )}
+      </ThumbnailContainer>
+      <Content>
         <h2>{title}</h2>
         <p>{writer}</p>
         <div>
           <div>{viewDate}</div>
           <div>조회수 {viewCount}</div>
         </div>
-      </Review>
+      </Content>
     </Container>
   );
 };
@@ -36,31 +48,47 @@ export default BlogReviewCard;
 
 const Container = styled.div`
   border: 1px solid ${theme.colors.greys60};
+  aspect-ratio: 1/1.05;
 `;
 
-const Image = styled.div`
+const ThumbnailContainer = styled.div`
+  position: relative;
   width: inherit;
-  height: fit-content;
-  & > img {
+  height: 62%;
+  img {
     width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+  .default-thumbnail {
+    position: absolute;
+    width: 50%;
+    height: auto;
+    top: 50%;
+    right: 50%;
+    transform: translate(50%, -50%);
+    border-radius: 0;
   }
 `;
 
-const Review = styled.div`
+const Content = styled.div`
+  height: 38%;
   padding: 30px;
-  & > h2 {
+  h2 {
+    margin-bottom: 4px;
+    color: ${theme.colors.greys90};
     font-weight: bold;
     font-size: 20px;
-    color: ${theme.colors.greys90};
-    margin-bottom: 4px;
+    line-height: 28px;
   }
-  & > p {
+  p {
+    margin-bottom: 20px;
+    color: ${theme.colors.greys60};
     font-weight: 500;
     font-size: 14px;
-    color: ${theme.colors.greys60};
-    margin-bottom: 20px;
+    line-height: 20px;
   }
-  & > div {
+  div {
     display: flex;
     justify-content: space-between;
     align-items: center;

--- a/src/components/mypage/WrittenBlogReview.tsx
+++ b/src/components/mypage/WrittenBlogReview.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "react-query";
 import { BlogReviewListRes, myBlogReviewsApi } from "../../apis/member";
 import useGetNewTokenApi from "../../apis/useGetRefreshToken";
 import isApiError from "../../utils/isApiError";
-import BlogReviewCard from "../blogreview/presentation/BlogReviewCard";
+import BlogReviewCard from "../blogReviewList/ReviewCard";
 import Pagination from "../Pagination";
 
 const WrittenBlogReview = () => {

--- a/src/pages/BlogReviewList.tsx
+++ b/src/pages/BlogReviewList.tsx
@@ -10,7 +10,7 @@ import blogReviewApis from "../apis/blogReviewApis";
 import Pagination from "../components/Pagination";
 import { BlogReviewResponse } from "../types/blogReview";
 
-const BlogReview = () => {
+const BlogReviewList = () => {
   const navigate = useNavigate();
   const [pages, setPages] = useState({
     started: 1,
@@ -95,7 +95,7 @@ const BlogReview = () => {
   );
 };
 
-export default BlogReview;
+export default BlogReviewList;
 
 const Container = styled.div`
   max-width: 1200px;

--- a/src/pages/BlogReviewList.tsx
+++ b/src/pages/BlogReviewList.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { useQuery } from "react-query";
 import { theme } from "../styles/theme";
 import Selectbox from "../components/atom/Selectbox";
-import ReviewCardList from "../components/blogreview/container/ReviewCardList";
+import ReviewCardList from "../components/blogReviewList/ReviewCardList";
 import Button from "../components/atom/Button";
 import blogReviewApis from "../apis/blogReviewApis";
 import Pagination from "../components/Pagination";

--- a/src/pages/BlogReviewList.tsx
+++ b/src/pages/BlogReviewList.tsx
@@ -102,7 +102,7 @@ const Title = styled.h2`
   font-size: 28px;
   color: ${theme.colors.greys90};
   text-align: center;
-  margin-bottom: 50px;
+  margin: 40px 0 50px;
 `;
 
 const Divider = styled.div`

--- a/src/pages/BlogReviewList.tsx
+++ b/src/pages/BlogReviewList.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { useQuery } from "react-query";
 import { theme } from "../styles/theme";
 import Selectbox from "../components/atom/Selectbox";
-import BlogReviewListWrapper from "../components/blogreview/container/BlogReviewList";
+import ReviewCardList from "../components/blogreview/container/ReviewCardList";
 import Button from "../components/atom/Button";
 import blogReviewApis from "../apis/blogReviewApis";
 import Pagination from "../components/Pagination";
@@ -78,19 +78,14 @@ const BlogReviewList = () => {
           </Button>
         </Flex>
       </SelectContainer>
-      {data ? (
-        <BlogReviewListWrapper
-          blogInfo={data.blogInfo}
-          pageInfo={data.pageInfo}
-        />
-      ) : null}
-      {totalPageNumber > 0 ? (
-        <Pagination
-          pages={pages}
-          setPages={setPages}
-          totalPage={totalPageNumber}
-        />
-      ) : null}
+      {data && (
+        <ReviewCardList blogInfo={data.blogInfo} pageInfo={data.pageInfo} />
+      )}
+      <Pagination
+        pages={pages}
+        setPages={setPages}
+        totalPage={totalPageNumber}
+      />
     </Container>
   );
 };


### PR DESCRIPTION
1. 디자인 수정
    -1) 리뷰 카드 비율 수정
    -2) 이미지 아래쪽 border-radius:0으로 수정
    -3) 전시 리뷰 제목이 nav바와 붙어있어서 여백 부여
    -4) 작성자가 이미지를 첨부하지 않은 경우 로고이미지 표시(임시)
    -5) 카드 호버 시 테두리, 그림자, 글자색 변경 반영
2. 코드 구조 변경
    -1) 블로그리뷰 상세/마이페이지 에 쓰이는 컴포넌트들과 블로그리뷰 목록페이지에 쓰이는 컴포넌트들이 한 폴더에 섞여있어 blogReviewList라는 파일을 생성해 전시리뷰목록페이지에서 사용하는 컴포넌트들은 위치 이동, 파일명 알아보기 쉽게 수정
    -2) 기존 BlogReview -> BlogReviewList로 컴포넌트명만 봐도 전시리뷰 목록 페이지인것을 알도록 파일명 수정
    -3) App.tsx에 import 순서가 맞지 않아 수정


css 코드 좀 더 간결하게 할 수 있을 것 같은데 저도 시간이 많이 없어서 일단 요구사항대로 구현했습니다.
동규님께서 블로그리뷰 카드의 넓이를 고정하셔서 화면넓이가 줄어드는 대로 비율이 줄어들지 않습니다.
이 부분은 나중에 전시회 목록 페이지처럼 수정 들어가면 좋을 것 같네요