### PR TITLE
Design: 전시회 상세페이지 상단 전시회 카드부분 디자인 수정

### DIFF
--- a/src/components/mate/CommentList.tsx
+++ b/src/components/mate/CommentList.tsx
@@ -57,7 +57,7 @@ const CommentListContainer = styled.div`
   max-width: 1200px;
   margin-bottom: 50px;
   padding: 30px;
-  border: 1px solid #e0e0e0;
+  border: 1px solid ${theme.colors.greys40};
   .comment-count {
     padding-bottom: 14px;
     border-bottom: 1px solid ${theme.colors.greys40};

--- a/src/components/mate/CommentList.tsx
+++ b/src/components/mate/CommentList.tsx
@@ -53,8 +53,11 @@ const CommentList = (props: CommentListType) => {
 export default CommentList;
 
 const CommentListContainer = styled.div`
-  border: 1px solid #e0e0e0;
+  width: 83vw;
+  max-width: 1200px;
+  margin-bottom: 50px;
   padding: 30px;
+  border: 1px solid #e0e0e0;
   .comment-count {
     padding-bottom: 14px;
     border-bottom: 1px solid ${theme.colors.greys40};

--- a/src/components/mate/ExhbCard.tsx
+++ b/src/components/mate/ExhbCard.tsx
@@ -67,6 +67,8 @@ const ExhbCardContainer = styled.div`
 const Thumbnail = styled.img`
   width: 31.6%;
   object-fit: cover;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
 `;
 
 const InfoContainer = styled.div`

--- a/src/components/mate/ExhbCard.tsx
+++ b/src/components/mate/ExhbCard.tsx
@@ -13,7 +13,7 @@ interface ExhbCardType {
   };
 }
 
-// 메이트 모집글 전시회 카드컴포넌트_박예선_23.01.26
+// 메이트 모집글 전시회 카드컴포넌트_박예선_23.02.08
 const ExhbCard = (props: ExhbCardType) => {
   const { exhbData } = props;
   const {
@@ -30,13 +30,17 @@ const ExhbCard = (props: ExhbCardType) => {
       <InfoContainer>
         <div className="title">{exhibitionTitle}</div>
         <DetailContainer>
-          <div className="date flex">
+          <div className="flex">
             <div className="detail-name">일정</div>
             <div>{exhibitionDuration}</div>
           </div>
           <div className="flex">
             <div className="detail-name">장소</div>
             <div>{exhibitionSpace}</div>
+          </div>
+          <div className="flex">
+            <div className="detail-name">전시 유형</div>
+            <div>전시 유형 추가돼서 연결해야 함(임시임)</div>
           </div>
         </DetailContainer>
       </InfoContainer>
@@ -48,9 +52,12 @@ export default ExhbCard;
 
 const ExhbCardContainer = styled.div`
   display: flex;
+  width: 83vw;
+  max-width: 1200px;
   height: 244px;
-  margin: 14px 0 30px;
+  margin-top: 14px;
   border: 1px solid ${theme.colors.greys40};
+  background-color: ${theme.colors.white100};
   cursor: pointer;
   .flex {
     display: flex;
@@ -58,14 +65,12 @@ const ExhbCardContainer = styled.div`
 `;
 
 const Thumbnail = styled.img`
-  width: 175px;
-  height: inherit;
+  width: 31.6%;
   object-fit: cover;
 `;
 
 const InfoContainer = styled.div`
-  margin: 30px;
-  border-radius: 0;
+  padding: 30px;
   .title {
     height: 104px;
     color: ${(props) => props.theme.colors.greys90};
@@ -76,22 +81,19 @@ const InfoContainer = styled.div`
 `;
 
 const DetailContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
   height: 50px;
-  margin-top: 30px;
-  div {
-    div {
-      font-size: 14px;
-      font-weight: 500;
-      line-height: 20px;
-      color: ${theme.colors.greys90};
-      &.detail-name {
-        width: 72px;
-        margin-right: 30px;
-        color: ${theme.colors.greys60};
-      }
-    }
-    &.date {
-      margin-bottom: 10px;
+  div > div {
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 20px;
+    color: ${theme.colors.greys90};
+    &.detail-name {
+      width: 72px;
+      margin-right: 30px;
+      color: ${theme.colors.greys60};
     }
   }
 `;

--- a/src/components/mate/MateTop.tsx
+++ b/src/components/mate/MateTop.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+import { useMateDeleteApi } from "../../apis/mate";
+import { theme } from "../../styles/theme";
+import { MateRes } from "../../types/mate";
+import ExhbCard from "./ExhbCard";
+
+interface MateTopType {
+  isMyPost: boolean;
+  mateId: number;
+  mateInfo: MateRes;
+}
+
+// 메이트 상세페이지 상단 배경색 있는 부분 컴포넌트_박예선_23.02.08
+const MateTop = (props: MateTopType) => {
+  const { isMyPost, mateId, mateInfo } = props;
+  const navigate = useNavigate();
+  const mateDeleteApi = useMateDeleteApi();
+
+  // 메이트글 삭제 api 호출_박예선_23.01.31
+  const clickDeleteBtn = async () => {
+    await mateDeleteApi(mateId);
+  };
+
+  return (
+    <MateTopContainer>
+      <TopBtnsContainer>
+        <div>
+          <BtnTransparent onClick={() => navigate("/mate-list")}>
+            목록
+          </BtnTransparent>
+          <BtnTransparent onClick={() => alert("준비중 붙이기")}>
+            이전 글
+          </BtnTransparent>
+          <BtnTransparent onClick={() => alert("준비중 붙이기")}>
+            다음 글
+          </BtnTransparent>
+          {/* 준비중 알림창 붙이기 */}
+        </div>
+        <div className={isMyPost ? "" : "none"}>
+          <BtnTransparent
+            onClick={() => navigate(`/mate-write?mateId=${mateId}`)}
+          >
+            수정
+          </BtnTransparent>
+          <BtnTransparent onClick={clickDeleteBtn}>삭제</BtnTransparent>
+        </div>
+      </TopBtnsContainer>
+      <ExhbCard exhbData={mateInfo.exhibition} />
+    </MateTopContainer>
+  );
+};
+
+export default MateTop;
+
+const MateTopContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100vw;
+  padding: 50px 0;
+  border-radius: 0;
+  background-color: #958da50d;
+`;
+
+const TopBtnsContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 83vw;
+  max-width: 1200px;
+  height: 40px;
+  div {
+    display: flex;
+    gap: 10px;
+  }
+`;
+
+export const BtnColored = styled.button`
+  height: 36px;
+  padding: 0 20px;
+  background-color: ${theme.colors.primry60};
+  color: ${theme.colors.white100};
+  font-size: 14px;
+  cursor: pointer;
+  &:disabled {
+    cursor: default;
+  }
+`;
+
+export const BtnTransparent = styled.button`
+  height: 40px;
+  padding: 0 20px;
+  border: 1px solid ${theme.colors.greys40};
+  background-color: ${theme.colors.white100};
+  font-size: 14px;
+  cursor: pointer;
+  &:disabled {
+    cursor: default;
+  }
+  :hover {
+    background-color: ${theme.colors.greys5};
+  }
+  &.bookmark {
+    margin: auto;
+    align-items: center;
+    span {
+      margin-left: 10px;
+      font-weight: 700;
+    }
+    :hover {
+      background-color: ${theme.colors.greys10};
+    }
+    &:focus-visible {
+      border: 1px solid ${theme.colors.greys100};
+    }
+    &.bookmarked {
+      background-color: ${theme.colors.primry80};
+      color: ${theme.colors.white100};
+    }
+  }
+`;

--- a/src/pages/Mate.tsx
+++ b/src/pages/Mate.tsx
@@ -2,28 +2,25 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { AxiosResponse } from "axios";
 import styled from "styled-components";
-import profileImg from "../assets/icons/profileImg.svg";
-import Calender from "../components/Calendar";
-import { MateRes } from "../types/mate";
 import { theme } from "../styles/theme";
+import profileImg from "../assets/icons/profileImg.svg";
+import { MateRes } from "../types/mate";
+import { BookMarkRes, mateApi, useMateBookMarkApi } from "../apis/mate";
+import isApiError from "../utils/isApiError";
+import MateTop, {
+  BtnColored,
+  BtnTransparent,
+} from "../components/mate/MateTop";
+import Calender from "../components/Calendar";
 import CommentList, {
   SubTitle,
   TextArea,
 } from "../components/mate/CommentList";
-import ExhbCard from "../components/mate/ExhbCard";
-import {
-  BookMarkRes,
-  mateApi,
-  useMateBookMarkApi,
-  useMateDeleteApi,
-} from "../apis/mate";
-import isApiError from "../utils/isApiError";
 
-// 메이트 모집글 상세페이지_박예선_23.01.27
+// 메이트 모집글 상세페이지_박예선_23.02.08
 const Mate = () => {
   const navigate = useNavigate();
   const mateBookMarkApi = useMateBookMarkApi();
-  const mateDeleteApi = useMateDeleteApi();
   const mateId = Number(useParams().id);
   const memberId = Number(localStorage.getItem("memberId"));
   const [isMyPost, setIsMyPost] = useState(false);
@@ -66,11 +63,6 @@ const Mate = () => {
     if (mateAuthorId === memberId) setIsMyPost(true);
   }, [mateInfo, mateInfo?.member, memberId]);
 
-  // 메이트글 삭제 api 호출_박예선_23.01.31
-  const clickDeleteBtn = async () => {
-    await mateDeleteApi(mateId);
-  };
-
   // 메이트글 북마크 등록/해제 api 호출_박예선_23.01.26
   const clickBookmarkBtn = async () => {
     if (!memberId) {
@@ -89,23 +81,7 @@ const Mate = () => {
   return (
     mateInfo && (
       <MateContainer>
-        <div className="top-buttons-container flex">
-          <BtnTransparent onClick={() => navigate("/mate-list")}>
-            목록
-          </BtnTransparent>
-          {/* <BtnTransparent>이전 글</BtnTransparent>
-          <BtnTransparent>다음 글</BtnTransparent> */}
-          {/* 일단 구현 중지 */}
-          <div className={isMyPost ? "" : "none"}>
-            <BtnTransparent
-              onClick={() => navigate(`/mate-write?mateId=${mateId}`)}
-            >
-              수정
-            </BtnTransparent>
-            <BtnTransparent onClick={clickDeleteBtn}>삭제</BtnTransparent>
-          </div>
-        </div>
-        <ExhbCard exhbData={mateInfo.exhibition} />
+        <MateTop isMyPost={isMyPost} mateId={mateId} mateInfo={mateInfo} />
         <MateContentContainer>
           <div className="flex">
             <div className="title-container">
@@ -160,6 +136,12 @@ const Mate = () => {
               disabled
             />
           </div>
+          <div>
+            <SubTitle type="greys90" marginTop={50}>
+              연락가능 메신저
+            </SubTitle>
+            <Span size={14}>{mateInfo.contact}</Span>
+          </div>
           <MemberInfo className="flex">
             <MemberProfileImg
               alt="member profile img"
@@ -175,12 +157,6 @@ const Mate = () => {
               <span>{getMemberAgeForm(mateInfo.member.memberAge)}</span>
             </div>
           </MemberInfo>
-          <div>
-            <SubTitle type="greys90" marginTop={50}>
-              연락가능 메신저
-            </SubTitle>
-            <Span size={14}>{mateInfo.contact}</Span>
-          </div>
           <div className="bookmark-container">
             <BtnTransparent
               type="button"
@@ -220,13 +196,10 @@ function getMemberAgeForm(year: string) {
 }
 
 const MateContainer = styled.div`
-  width: 83vw;
-  max-width: 1200px;
-  margin: 50px auto;
-  .top-buttons-container {
-    height: 40px;
-    justify-content: space-between;
-  }
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100vw;
   .flex {
     display: flex;
   }
@@ -236,9 +209,12 @@ const MateContainer = styled.div`
 `;
 
 const MateContentContainer = styled.div`
-  margin: 30px 0;
+  width: 83vw;
+  max-width: 1200px;
+  margin: 50px 0 30px;
   padding: 30px;
   border: 1px solid ${theme.colors.greys40};
+  background-color: ${theme.colors.white100};
   .title-container {
     width: 100%;
     padding-bottom: 15px;
@@ -309,50 +285,6 @@ const MemberProfileImg = styled.img`
   height: 78px;
   margin-right: 10px;
   border-radius: 50px;
-`;
-
-export const BtnColored = styled.button`
-  height: 36px;
-  padding: 0 20px;
-  background-color: ${theme.colors.primry60};
-  color: ${theme.colors.white100};
-  font-size: 14px;
-  cursor: pointer;
-  &:disabled {
-    cursor: default;
-  }
-`;
-
-const BtnTransparent = styled.button`
-  height: 40px;
-  padding: 0 20px;
-  border: 1px solid ${theme.colors.greys40};
-  font-size: 14px;
-  cursor: pointer;
-  &:disabled {
-    cursor: default;
-  }
-  &:nth-child(1) {
-    margin-right: 10px;
-  }
-  &.bookmark {
-    margin: auto;
-    align-items: center;
-    span {
-      margin-left: 10px;
-      font-weight: 700;
-    }
-    :hover {
-      background-color: ${theme.colors.greys10};
-    }
-    &:focus-visible {
-      border: 1px solid ${theme.colors.greys100};
-    }
-    &.bookmarked {
-      background-color: ${theme.colors.primry80};
-      color: ${theme.colors.white100};
-    }
-  }
 `;
 
 const Span = styled.span<{ size: number }>`


### PR DESCRIPTION
1. 썸네일 넓이 증가
2. 썸네일 우측 테두리 직선으로 변경
3. 상단 전시회 부분 배경색 추가
4. 전시회카드 부분 '전시유형' 추가 -> 백엔드에서 데이터 추가해줘야 해서 아직 데이터랑 연결은 안됨.
5. 이전글, 다음글 버튼 추가 -> 기능은 막아둠(alert)

상세페이지 하단은 아직 변경이 더 필요한데 블로그리뷰 상세페이지에도 이 카드 컴포넌트를 사용해야해서 먼저 pr합니다