### PR TITLE
Fix: Calendar 컴포넌트 기존 선택된 날짜 보이지 않던 버그 수정, 메이트 모집글 작성/수정페이지 달력 변경사항 반영

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -22,7 +22,9 @@ interface CalendarProps {
 
 const Calender = ({ selectedDate, handleSelectedDate }: CalendarProps) => {
   const [showedMonth, setShowedMonth] = useState<Date>(selectedDate);
-  const [selectedNumber, setSelectedNumber] = useState(selectedDate.getDate());
+  const [selectedDayNumber, setSelectedDayNumber] = useState(
+    selectedDate.getDate()
+  );
 
   const calendarDays = useMemo(
     () => getCalendarDays(showedMonth),
@@ -31,7 +33,7 @@ const Calender = ({ selectedDate, handleSelectedDate }: CalendarProps) => {
 
   useEffect(() => {
     setShowedMonth(selectedDate);
-    setSelectedNumber(selectedDate.getDate());
+    setSelectedDayNumber(selectedDate.getDate());
   }, [selectedDate, setShowedMonth]);
 
   const clickArrowLeft = () => {
@@ -49,7 +51,7 @@ const Calender = ({ selectedDate, handleSelectedDate }: CalendarProps) => {
     if (e.target.dataset.valid === "true") {
       const day = e.target.dataset.value as string;
       const numberDay = parseInt(day, 10);
-      setSelectedNumber(numberDay);
+      setSelectedDayNumber(numberDay);
 
       const selectedDay = new Date(
         getYear(showedMonth),
@@ -94,7 +96,7 @@ const Calender = ({ selectedDate, handleSelectedDate }: CalendarProps) => {
         {calendarDays.map((each) => (
           <Day
             key={each.id}
-            className={each.day === selectedNumber ? "selected" : ""}
+            className={each.day === selectedDayNumber ? "selected" : ""}
             data-valid={each.isValid}
             data-value={each.day}
             onClick={clickCalendarDay}

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useId, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   format,
   addMonths,
@@ -16,28 +16,34 @@ import arrowLeft from "../assets/icons/arrowLeft.svg";
 import arrowRight from "../assets/icons/arrowRight.svg";
 
 interface CalendarProps {
+  selectedDate: Date;
   handleSelectedDate: (date: string) => void;
 }
 
-const Calender = ({ handleSelectedDate }: CalendarProps) => {
-  const [currentMonth, setCurrentMonth] = useState<Date>(new Date());
-  const [selectedNumber, setSelectedNumber] = useState(new Date().getDate());
+const Calender = ({ selectedDate, handleSelectedDate }: CalendarProps) => {
+  const [showedMonth, setShowedMonth] = useState<Date>(selectedDate);
+  const [selectedNumber, setSelectedNumber] = useState(selectedDate.getDate());
 
   const calendarDays = useMemo(
-    () => getCalendarDays(currentMonth),
-    [currentMonth]
+    () => getCalendarDays(showedMonth),
+    [showedMonth]
   );
 
-  const prevMonth = () => {
-    const prevDate = subMonths(currentMonth, 1);
-    setCurrentMonth(prevDate);
+  useEffect(() => {
+    setShowedMonth(selectedDate);
+    setSelectedNumber(selectedDate.getDate());
+  }, [selectedDate, setShowedMonth]);
+
+  const clickArrowLeft = () => {
+    const prevDate = subMonths(showedMonth, 1);
+    handleSelectedDate(format(prevDate, "yyyy-MM-dd"));
   };
-  const nextMonth = () => {
-    const nextDate = addMonths(currentMonth, 1);
-    setCurrentMonth(nextDate);
+  const clickArrowRight = () => {
+    const nextDate = addMonths(showedMonth, 1);
+    handleSelectedDate(format(nextDate, "yyyy-MM-dd"));
   };
 
-  const onDateSelect = (e: React.SyntheticEvent<HTMLDivElement>) => {
+  const clickCalendarDay = (e: React.SyntheticEvent<HTMLDivElement>) => {
     if (!(e.target instanceof HTMLDivElement)) return;
 
     if (e.target.dataset.valid === "true") {
@@ -46,8 +52,8 @@ const Calender = ({ handleSelectedDate }: CalendarProps) => {
       setSelectedNumber(numberDay);
 
       const selectedDay = new Date(
-        getYear(currentMonth),
-        getMonth(currentMonth),
+        getYear(showedMonth),
+        getMonth(showedMonth),
         parseInt(day, 10)
       );
 
@@ -61,15 +67,15 @@ const Calender = ({ handleSelectedDate }: CalendarProps) => {
     <CalendarWrapper>
       <Header>
         <div>
-          <button type="button" onClick={prevMonth}>
+          <button type="button" onClick={clickArrowLeft}>
             <img src={arrowLeft} alt="이전 화살표" />
           </button>
         </div>
         <div>
-          {format(currentMonth, "M")}월 {format(currentMonth, "yyyy")}
+          {format(showedMonth, "M")}월 {format(showedMonth, "yyyy")}
         </div>
         <div>
-          <button type="button" onClick={nextMonth}>
+          <button type="button" onClick={clickArrowRight}>
             <img src={arrowRight} alt="다음 화살표" />
           </button>
         </div>
@@ -84,13 +90,14 @@ const Calender = ({ handleSelectedDate }: CalendarProps) => {
         <div>금</div>
         <div>토</div>
       </DayOfWeek>
-      <Week onClick={onDateSelect} onKeyDown={onDateSelect} role="presentation">
+      <Week role="presentation">
         {calendarDays.map((each) => (
           <Day
             key={each.id}
             className={each.day === selectedNumber ? "selected" : ""}
             data-valid={each.isValid}
             data-value={each.day}
+            onClick={clickCalendarDay}
           >
             {each.day}
           </Day>
@@ -102,8 +109,8 @@ const Calender = ({ handleSelectedDate }: CalendarProps) => {
 
 export default Calender;
 
-function getCalendarDays(currentMonth: Date) {
-  const monthStartDate = startOfMonth(currentMonth);
+function getCalendarDays(selectedDate: Date) {
+  const monthStartDate = startOfMonth(selectedDate);
   const monthEndDate = endOfMonth(monthStartDate);
 
   const calendarStartDate = startOfWeek(monthStartDate);
@@ -120,7 +127,7 @@ function getCalendarDays(currentMonth: Date) {
   return calendarDays;
 
   function getPrevDays() {
-    const prevLastDay = format(endOfMonth(subMonths(currentMonth, 1)), "d");
+    const prevLastDay = format(endOfMonth(subMonths(selectedDate, 1)), "d");
     const monthFirstDay = format(calendarStartDate, "d");
     if (format(monthStartDate, "d") === format(calendarStartDate, "d"))
       return [];
@@ -180,6 +187,9 @@ const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  button:hover {
+    cursor: pointer;
+  }
 `;
 
 const Divider = styled.div`

--- a/src/pages/BlogReviewModify.tsx
+++ b/src/pages/BlogReviewModify.tsx
@@ -326,7 +326,10 @@ const BlogReviewUpdate = () => {
           />
           <div>
             <SubTitle text="관람일" />
-            <Calender handleSelectedDate={setSelectedDate} />
+            <Calender
+              selectedDate={new Date()}
+              handleSelectedDate={setSelectedDate}
+            />
           </div>
         </ExhibitionPicker>
         <SelectorConatiner>

--- a/src/pages/BlogReviewWrite.tsx
+++ b/src/pages/BlogReviewWrite.tsx
@@ -295,7 +295,10 @@ const BlogReviewWrite = () => {
           />
           <div>
             <SubTitle text="관람일" />
-            <Calender handleSelectedDate={setSelectedDate} />
+            <Calender
+              selectedDate={new Date()}
+              handleSelectedDate={setSelectedDate}
+            />
           </div>
         </ExhibitionPicker>
         <SelectorConatiner>

--- a/src/pages/Mate.tsx
+++ b/src/pages/Mate.tsx
@@ -122,7 +122,7 @@ const Mate = () => {
             <SubTitle type="greys90" marginTop={50}>
               관람예정일
             </SubTitle>
-            <Calender handleSelectedDate={() => {}} />
+            <Calender selectedDate={new Date()} handleSelectedDate={() => {}} />
           </div>
           <div>
             <SubTitle type="greys90" marginTop={50}>

--- a/src/pages/MateWrite.tsx
+++ b/src/pages/MateWrite.tsx
@@ -3,6 +3,7 @@ import { AxiosResponse } from "axios";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import styled from "styled-components";
+import format from "date-fns/format";
 import { theme } from "../styles/theme";
 import plus from "../assets/icons/plus.svg";
 import Button from "../components/atom/Button";
@@ -20,7 +21,7 @@ import isApiError from "../utils/isApiError";
 import { alertError } from "../utils/alerts";
 import Modal from "../Modal";
 
-// 메이트글 작성/수정 페이지_박예선_23.02.08
+// 메이트글 작성/수정 페이지_박예선_23.02.09
 const MateWrite = () => {
   const refreshTokenApi = useRefreshTokenApi();
   const location = useLocation();
@@ -36,7 +37,7 @@ const MateWrite = () => {
     status: "모집 중",
     mateGender: "성별 무관",
     mateAge: "",
-    availableDate: "",
+    availableDate: format(new Date(), "yyyy-MM-dd"),
     content: "",
     contact: "",
     exhibitionId: 0,
@@ -45,7 +46,6 @@ const MateWrite = () => {
     minimum: "",
     maximum: "",
   });
-  const [selectedDate, setSelectedDate] = useState("");
   const [openExhbModal, setOpenExhbModal] = useState(false);
   const [exhbData, setExhbData] = useState({
     thumbnail: "",
@@ -230,19 +230,20 @@ const MateWrite = () => {
       setWriteData({ ...writeData, mateAge: `${minimum} ~ ${maximum}` });
   };
 
-  // 관람일 미정 체크박스 클릭함수_박예선_23.01.28
+  // 관람일 미정 체크박스 클릭함수_박예선_23.02.09
   const clickDateRegardless = () => {
     if (availableDate !== "미정")
       setWriteData({ ...writeData, availableDate: "미정" });
     if (availableDate === "미정")
-      setWriteData({ ...writeData, availableDate: selectedDate });
+      setWriteData({
+        ...writeData,
+        availableDate: format(new Date(), "yyyy-MM-dd"),
+      });
   };
 
-  // 달력 클릭 함수_박예선_23.01.31
+  // 달력 클릭 함수_박예선_23.02.09
   const clickCalendar = (date: string) => {
-    setSelectedDate(date);
-    if (availableDate !== "미정")
-      setWriteData({ ...writeData, availableDate: date });
+    setWriteData({ ...writeData, availableDate: date });
   };
 
   // 전시회 선택 함수_박예선_23.02.08
@@ -377,7 +378,26 @@ const MateWrite = () => {
               onClick={clickDateRegardless}
             />
             <CalenderContainer>
-              <Calender handleSelectedDate={clickCalendar} />
+              {mateId !== 0 && (
+                <Calender
+                  selectedDate={
+                    writeData.availableDate === "미정"
+                      ? new Date()
+                      : new Date(writeData.availableDate)
+                  }
+                  handleSelectedDate={clickCalendar}
+                />
+              )}
+              {!mateId && (
+                <Calender
+                  selectedDate={
+                    writeData.availableDate === "미정"
+                      ? new Date()
+                      : new Date(writeData.availableDate)
+                  }
+                  handleSelectedDate={clickCalendar}
+                />
+              )}
             </CalenderContainer>
           </div>
         </Section>


### PR DESCRIPTION
‼️블로그리뷰나 메이트글 수정 페이지에 접속시 선택한 날짜가 아닌 당일날짜가 보이는 오류를 수정했습니다.

1. 캘린더 컴포넌트는 selectedDate라는 props를 받게됩니다. 부모 컴포넌트의 selectedDate가 변경되면 캘린더 컴포넌트의 날짜, 선택날짜도 변경되게 됩니다.
2. 수정하며 역할에 대한 의미를 확실하게 알 수 없어서 헷갈렸던 변수/함수명을 수정했습니다.
    - 캘린더에 표시되는 달을 나타내는 변수 : currentMonth -> showedMonth
    - 사용자가 선택한 날짜의 번호를 나타내는 변수 : selectedNumber -> selectedDayNumber
    - 달력의 오른쪽, 왼쪽 화살표 클릭 함수 : prevMonth/nextMonth -> clickArrowLeft, clickArrowRight
    - 달력 날짜 클릭함수 : onDateSelect -> clickCalendarDay
 3. 날짜가 아닌 날짜 사이사이를 클릭해도 날짜클릭함수가 발동하게 되어서 달력 전체가 아닌 날짜 요소에만 클릭이벤트를 주도록 수정했습니다
 4. 오른쪽/왼쪽 화살표 버튼에 hover해도 마우스가 바뀌지 않아 커서바뀌도록 수정했습니다.
 5. 달력컴포넌트의 수정사항을 반영해 메이트 모집글 작성/수정 컴포넌트를 수정했습니다

‼️ 기존 달력 컴포넌트를 사용한 컴포넌트들에는 일단 현재 날짜를 부여했습니다. 블로그리뷰 수정페이지에서 로직에 맞게 수정하셔야합니다.