### PR TITLE
Design: 검색input 컴포넌트화 후 전시리뷰 목록페이지에 적용

### DIFF
--- a/src/components/atom/SearchInput.tsx
+++ b/src/components/atom/SearchInput.tsx
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+import { theme } from "../../styles/theme";
+
+const SearchInput = styled.input`
+  width: 277px;
+  height: 36px;
+  padding: 0 54px 0 20px;
+  border: 1px solid ${theme.colors.greys40};
+  background: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='11' cy='11' r='6' stroke='%239C9C9C' stroke-width='2'/%3E%3Cpath d='M16.2071 14.7929L15.5 14.0858L14.0858 15.5L14.7929 16.2071L16.2071 14.7929ZM18.2929 19.7071C18.6834 20.0976 19.3166 20.0976 19.7071 19.7071C20.0976 19.3166 20.0976 18.6834 19.7071 18.2929L18.2929 19.7071ZM14.7929 16.2071L18.2929 19.7071L19.7071 18.2929L16.2071 14.7929L14.7929 16.2071Z' fill='%239C9C9C'/%3E%3C/svg%3E%0A")
+    no-repeat;
+  background-position: right 25px center;
+  font-size: 14px;
+  &::placeholder {
+    color: ${(props) => props.theme.colors.greys60};
+  }
+  &:hover {
+    cursor: text;
+  }
+`;
+
+export default SearchInput;

--- a/src/components/blogReviewList/ReviewCard.tsx
+++ b/src/components/blogReviewList/ReviewCard.tsx
@@ -43,7 +43,7 @@ const ReviewCard = ({
 export default ReviewCard;
 
 const Container = styled.div`
-  border: 1px solid ${theme.colors.greys60};
+  border: 1px solid ${theme.colors.greys40};
   aspect-ratio: 1/1.05;
   :hover {
     border: 1px solid ${theme.colors.primry60};

--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import styled from "styled-components";
 import { theme } from "../../styles/theme";
-import { FilterType } from "../../types/exhbList";
 import Button from "../atom/Button";
+import SearchInput from "../atom/SearchInput";
 import Selectbox from "../atom/Selectbox";
 import { PagesState } from "../Pagination";
+import { alertPreparing } from "../../utils/alerts";
+import { FilterType } from "../../types/exhbList";
 
 // 전시글 목록 상단 필터 컴포넌트_박예선_23.02.08
 const Filters = (props: FiltersType) => {
@@ -68,7 +70,7 @@ const Filters = (props: FiltersType) => {
           placeholder="검색"
           onClick={() => alert("준비 중인 기능입니다.")}
           onKeyDown={(e) => {
-            if (e.key === "Enter") alert("준비 중인 기능입니다.");
+            if (e.key === "Enter") alertPreparing();
           }}
         />
       </div>
@@ -135,19 +137,5 @@ const FiltersContainer = styled.div`
         margin-right: 10px;
       }
     }
-  }
-`;
-
-const SearchInput = styled.input`
-  width: 277px;
-  height: 36px;
-  padding: 0 42px 0 20px;
-  border: 1px solid ${(props) => props.theme.colors.greys40};
-  background: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='11' cy='11' r='6' stroke='%239C9C9C' stroke-width='2'/%3E%3Cpath d='M16.2071 14.7929L15.5 14.0858L14.0858 15.5L14.7929 16.2071L16.2071 14.7929ZM18.2929 19.7071C18.6834 20.0976 19.3166 20.0976 19.7071 19.7071C20.0976 19.3166 20.0976 18.6834 19.7071 18.2929L18.2929 19.7071ZM14.7929 16.2071L18.2929 19.7071L19.7071 18.2929L16.2071 14.7929L14.7929 16.2071Z' fill='%239C9C9C'/%3E%3C/svg%3E%0A")
-    no-repeat;
-  background-position: right 14px center;
-  font-size: 14px;
-  &::placeholder {
-    color: ${(props) => props.theme.colors.greys60};
   }
 `;

--- a/src/components/mate/MateListFilter.tsx
+++ b/src/components/mate/MateListFilter.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { theme } from "../../styles/theme";
 import Button from "../atom/Button";
 import Selectbox from "../atom/Selectbox";
+import SearchInput from "../atom/SearchInput";
 import { alertPreparing } from "../../utils/alerts";
 
 interface MateListFilterType {
@@ -96,22 +97,5 @@ const FilterContainer = styled.div`
   }
   .flex {
     display: flex;
-  }
-`;
-
-const SearchInput = styled.input`
-  width: 19.2vw;
-  height: 36px;
-  padding: 0 54px 0 20px;
-  border: 1px solid ${theme.colors.greys40};
-  background: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='11' cy='11' r='6' stroke='%239C9C9C' stroke-width='2'/%3E%3Cpath d='M16.2071 14.7929L15.5 14.0858L14.0858 15.5L14.7929 16.2071L16.2071 14.7929ZM18.2929 19.7071C18.6834 20.0976 19.3166 20.0976 19.7071 19.7071C20.0976 19.3166 20.0976 18.6834 19.7071 18.2929L18.2929 19.7071ZM14.7929 16.2071L18.2929 19.7071L19.7071 18.2929L16.2071 14.7929L14.7929 16.2071Z' fill='%239C9C9C'/%3E%3C/svg%3E%0A")
-    no-repeat;
-  background-position: right 25px center;
-  font-size: 14px;
-  &::placeholder {
-    color: ${(props) => props.theme.colors.greys60};
-  }
-  &:hover {
-    cursor: text;
   }
 `;

--- a/src/components/mate/MateListFilter.tsx
+++ b/src/components/mate/MateListFilter.tsx
@@ -11,7 +11,7 @@ interface MateListFilterType {
   setMateStatusFilter: React.Dispatch<React.SetStateAction<MateStatusType>>;
 }
 
-// 메이트목록 상단 필터, 검색 컴포넌트_박예선_23.02.08
+// 메이트목록 상단 필터, 검색 컴포넌트_박예선_23.02.10
 const MateListFilter = (props: MateListFilterType) => {
   const { setMateStatusFilter } = props;
   const navigate = useNavigate();
@@ -76,6 +76,8 @@ const MATE_STATUS_ARRAY: MateStatusType[] = ["전체", "모집 중", "모집 완
 const FilterContainer = styled.div`
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 10px;
   width: 100%;
   margin-bottom: 30px;
   padding-top: 14px;
@@ -91,11 +93,15 @@ const FilterContainer = styled.div`
   }
   .mate-write-btn {
     width: 130px;
-    margin-left: 10px;
     font-size: 14px;
     line-height: 20px;
   }
   .flex {
     display: flex;
+  }
+  div {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
   }
 `;

--- a/src/pages/BlogReviewList.tsx
+++ b/src/pages/BlogReviewList.tsx
@@ -53,7 +53,7 @@ const BlogReviewList = () => {
         <Flex>
           <Selectbox
             placeholder="최신 순"
-            options={["최신 순", "인기 순"]}
+            options={["최신 순", "조회수 순"]}
             width="130px"
             name="정렬 필터"
             onClick={handleOrderType}

--- a/src/pages/BlogReviewList.tsx
+++ b/src/pages/BlogReviewList.tsx
@@ -32,10 +32,6 @@ const BlogReviewList = () => {
     }
   };
 
-  const handleInputLength = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setInputLength(event.target.value.length);
-  };
-
   const { isLoading, isError, error, data } = useQuery<
     BlogReviewResponse,
     Error

--- a/src/pages/BlogReviewList.tsx
+++ b/src/pages/BlogReviewList.tsx
@@ -1,14 +1,16 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import styled from "styled-components";
 import { useQuery } from "react-query";
+import styled from "styled-components";
 import { theme } from "../styles/theme";
-import Selectbox from "../components/atom/Selectbox";
-import ReviewCardList from "../components/blogReviewList/ReviewCardList";
 import Button from "../components/atom/Button";
-import blogReviewApis from "../apis/blogReviewApis";
+import Selectbox from "../components/atom/Selectbox";
+import SearchInput from "../components/atom/SearchInput";
+import ReviewCardList from "../components/blogReviewList/ReviewCardList";
 import Pagination from "../components/Pagination";
+import { alertPreparing } from "../utils/alerts";
 import { BlogReviewResponse } from "../types/blogReview";
+import blogReviewApis from "../apis/blogReviewApis";
 
 const BlogReviewList = () => {
   const navigate = useNavigate();
@@ -62,12 +64,13 @@ const BlogReviewList = () => {
           />
         </Flex>
         <Flex style={{ gap: "10px" }}>
-          <InputContainer>
-            <Input onChange={handleInputLength} />
-            <InputLegnth inputlength={inputLength}>
-              {inputLength}/60
-            </InputLegnth>
-          </InputContainer>
+          <SearchInput
+            placeholder="검색"
+            onClick={() => {}}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") alertPreparing();
+            }}
+          />
           <Button
             onClick={() => navigate("/blogreview-write")}
             style={{ padding: "8px 20px" }}
@@ -123,32 +126,4 @@ const Flex = styled.div`
   display: flex;
   align-items: center;
   gap: 4px;
-`;
-
-const InputContainer = styled.div`
-  position: relative;
-`;
-
-const Input = styled.input`
-  width: 277px;
-  height: 36px;
-  margin: 10px auto;
-  padding-left: 10px;
-  border: 1px solid ${theme.colors.greys40};
-  border-radius: 30px;
-`;
-
-interface InputProps {
-  inputlength: number;
-}
-
-const InputLegnth = styled.div<InputProps>`
-  position: absolute;
-  top: 50%;
-  right: 10px;
-  transform: translateY(-50%);
-  color: ${(props) =>
-    props.inputlength > 60 ? theme.colors.error : theme.colors.greys60};
-  font-weight: 500;
-  font-size: 14px;
 `;

--- a/src/pages/BlogReviewList.tsx
+++ b/src/pages/BlogReviewList.tsx
@@ -49,7 +49,7 @@ const BlogReviewList = () => {
     <Container>
       <Title>전시 리뷰</Title>
       <Divider />
-      <SelectContainer>
+      <TopLineContainer>
         <Flex>
           <Selectbox
             placeholder="최신 순"
@@ -76,7 +76,7 @@ const BlogReviewList = () => {
             리뷰 등록
           </Button>
         </Flex>
-      </SelectContainer>
+      </TopLineContainer>
       {data && (
         <ReviewCardList blogInfo={data.blogInfo} pageInfo={data.pageInfo} />
       )}
@@ -110,10 +110,12 @@ const Divider = styled.div`
   margin-bottom: 14px;
 `;
 
-const SelectContainer = styled.div`
+const TopLineContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
   padding: 0px;
   margin-bottom: 30px;
 `;


### PR DESCRIPTION
1. 제가 기존 작성했던 검색 input을 컴포넌트화 한 후 atom폴더에 넣었습니다.
    - Searchbar라는 컴포넌트가 있긴 했는데 적용된 부분을 보니 아직 페이지 레이아웃이 미완이라 혹시 깨질까봐 제가 새로 만들었습니다.
2. 전시리뷰 목록페이지에 검색input이 피그마와 다른 형태로 들어가있어 컴포넌트를 이용해 수정했습니다
    - 돋보기 아이콘이 없고 글자수 표시가 있었음
    - 기능은 막아뒀음
3. 전시회목록/메이트글 목록 페이지의 검색창을 아톰 컴포넌트를 활용해서 수정했습니다.(디자인은 기존과 같음)