### PR TITLE
Setting: 공통적으로 사용되는 Bg 컬러 추가

### DIFF
--- a/src/components/mate/MateTop.tsx
+++ b/src/components/mate/MateTop.tsx
@@ -61,7 +61,7 @@ const MateTopContainer = styled.div`
   width: 100vw;
   padding: 50px 0;
   border-radius: 0;
-  background-color: #958da50d;
+  background-color: ${theme.colors.pageBg};
 `;
 
 const TopBtnsContainer = styled.div`

--- a/src/styles/theme.tsx
+++ b/src/styles/theme.tsx
@@ -24,6 +24,7 @@ const colors = {
   greys100: "#1C1C1C",
   success: "#54C60E",
   error: "#FD3D51",
+  pageBg: "#958da50d",
 };
 
 export type Responsive = typeof responsive;


### PR DESCRIPTION
- 피그마 페이지별 타이틀이나 전시카드 뒤의 Bg컬러가 모두 같다는 것을 진아님께 확인받았습니다.
    - 피그마상 rgba(149, 141, 165, 0.05); 컬러. => #958DA5에 투명도 5%인.
    - hex코드로 변경후 반영했습니다
- 바로는 아니더라도 추후 이 속성이용해서 변경해주시면 좋을 것 같아요!
- 확인을 위해 메이트글 상세페이지에 적용해보았습니다. 잘 작동합니다!