### PR TITLE
Design: 메인페이지 반응형으로 수정

### DIFF
--- a/src/components/main/MainArticle.tsx
+++ b/src/components/main/MainArticle.tsx
@@ -23,7 +23,9 @@ const MainArticle = () => {
         <Exhibition stroke={exhbStroke} />
         <div>
           <h3>전시회</h3>
-          <p>다양한 전시 정보를 찾아보세요</p>
+          <p className="card-discription">
+            <span>다양한 전시 정보를</span> 찾아보세요
+          </p>
         </div>
         <LinkContainer>
           <span className="linkContainer">자세히 보기</span>
@@ -38,7 +40,9 @@ const MainArticle = () => {
         <Review stroke={reviewStroke} />
         <div>
           <h3>전시 리뷰</h3>
-          <p>다양한 전시 리뷰 를 찾아보세요</p>
+          <p className="card-discription">
+            <span>다양한 전시 리뷰를</span> 찾아보세요
+          </p>
         </div>
         <LinkContainer>
           <span className="linkContainer">자세히 보기</span>
@@ -53,7 +57,10 @@ const MainArticle = () => {
         <Mate stroke={mateStroke} />
         <div>
           <h3>메이트</h3>
-          <p>전시회에 같이 갈 친구를 찾아보세요</p>
+          <p className="card-discription">
+            <span>전시회에 같이 갈</span>
+            <span>친구를</span> 찾아보세요
+          </p>
         </div>
         <LinkContainer className="linkContainer">
           <span>자세히 보기</span>
@@ -109,6 +116,22 @@ const Article = styled.article`
     p,
     .linkContainer {
       color: ${theme.colors.primry80};
+    }
+  }
+  .card-discription {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 2.5px;
+  }
+  @media (max-width: 1439px) {
+    & h3 {
+      font-size: 1.9vw;
+    }
+  }
+  @media (max-width: 1064px) {
+    & h3 {
+      font-size: 21px;
     }
   }
 `;

--- a/src/components/main/MainArticle.tsx
+++ b/src/components/main/MainArticle.tsx
@@ -28,13 +28,13 @@ const MainArticle = () => {
             <span>전시 정보를</span> 찾아보세요
           </p>
         </CardTextContainer>
-        <LinkContainer>
+        <SeeMore>
           <p>
             <span>자세히</span>
             보기
           </p>
           <img src={arrowRight} alt="자세히 보기" />
-        </LinkContainer>
+        </SeeMore>
       </Article>
       <Article
         onMouseOver={() => setReviewStroke(`${theme.colors.primry80}`)}
@@ -49,13 +49,13 @@ const MainArticle = () => {
             <span>전시 리뷰를</span> 찾아보세요
           </p>
         </CardTextContainer>
-        <LinkContainer>
+        <SeeMore>
           <p>
             <span>자세히</span>
             보기
           </p>
           <img src={arrowRight} alt="자세히 보기" />
-        </LinkContainer>
+        </SeeMore>
       </Article>
       <Article
         onMouseOver={() => setMateStroke(`${theme.colors.primry80}`)}
@@ -71,12 +71,12 @@ const MainArticle = () => {
             <span>친구를</span> 찾아보세요
           </p>
         </CardTextContainer>
-        <LinkContainer>
+        <SeeMore>
           <p>
             <span>자세히</span> 보기
           </p>
           <img src={arrowRight} alt="자세히 보기" />
-        </LinkContainer>
+        </SeeMore>
       </Article>
     </ArticleContainer>
   );
@@ -149,7 +149,7 @@ const CardTextContainer = styled.div`
   }
 `;
 
-const LinkContainer = styled.div`
+const SeeMore = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/main/MainArticle.tsx
+++ b/src/components/main/MainArticle.tsx
@@ -21,19 +21,19 @@ const MainArticle = () => {
         onClick={() => navigate("/exhibition-list")}
       >
         <Exhibition stroke={exhbStroke} />
-        <div>
+        <CardTextContainer>
           <h3>전시회</h3>
-          <p className="card-discription">
+          <p>
             <span>다양한</span>
             <span>전시 정보를</span> 찾아보세요
           </p>
-        </div>
+        </CardTextContainer>
         <LinkContainer>
           <p>
             <span>자세히</span>
             보기
           </p>
-          <img src={arrowRight} alt="" />
+          <img src={arrowRight} alt="자세히 보기" />
         </LinkContainer>
       </Article>
       <Article
@@ -42,19 +42,19 @@ const MainArticle = () => {
         onClick={() => navigate("/blogreview-list")}
       >
         <Review stroke={reviewStroke} />
-        <div>
+        <CardTextContainer>
           <h3>전시 리뷰</h3>
-          <p className="card-discription">
+          <p>
             <span>다양한</span>
             <span>전시 리뷰를</span> 찾아보세요
           </p>
-        </div>
+        </CardTextContainer>
         <LinkContainer>
           <p>
             <span>자세히</span>
             보기
           </p>
-          <img src={arrowRight} alt="" />
+          <img src={arrowRight} alt="자세히 보기" />
         </LinkContainer>
       </Article>
       <Article
@@ -63,19 +63,19 @@ const MainArticle = () => {
         onClick={() => navigate("/mate-list")}
       >
         <Mate stroke={mateStroke} />
-        <div>
+        <CardTextContainer>
           <h3>메이트</h3>
-          <p className="card-discription">
+          <p>
             <span>전시회에</span>
             <span>같이 갈</span>
             <span>친구를</span> 찾아보세요
           </p>
-        </div>
+        </CardTextContainer>
         <LinkContainer>
           <p>
             <span>자세히</span> 보기
           </p>
-          <img src={arrowRight} alt="" />
+          <img src={arrowRight} alt="자세히 보기" />
         </LinkContainer>
       </Article>
     </ArticleContainer>
@@ -112,28 +112,30 @@ const Article = styled.article`
   text-align: center;
   z-index: 99;
   cursor: pointer;
-  & h3 {
-    margin-bottom: 1rem;
-    font-weight: bold;
-    font-size: 28px;
-  }
-  & p {
-    color: ${theme.colors.greys60};
-    font-size: 14px;
-  }
   &:hover {
     border: 1px solid ${theme.colors.primry60};
+    box-shadow: 0px 0px 20px rgba(56, 30, 114, 0.1);
     & h3,
     p,
     span {
       color: ${theme.colors.primry80};
     }
   }
-  .card-discription {
+`;
+
+const CardTextContainer = styled.div`
+  h3 {
+    margin-bottom: 1rem;
+    font-weight: bold;
+    font-size: 28px;
+  }
+  p {
     display: flex;
     justify-content: center;
     flex-wrap: wrap;
     gap: 2.5px;
+    color: ${theme.colors.greys60};
+    font-size: 14px;
   }
   @media (max-width: 1439px) {
     & h3 {

--- a/src/components/main/MainArticle.tsx
+++ b/src/components/main/MainArticle.tsx
@@ -24,11 +24,15 @@ const MainArticle = () => {
         <div>
           <h3>전시회</h3>
           <p className="card-discription">
-            <span>다양한 전시 정보를</span> 찾아보세요
+            <span>다양한</span>
+            <span>전시 정보를</span> 찾아보세요
           </p>
         </div>
-        <LinkContainer>
-          <span className="linkContainer">자세히 보기</span>
+        <LinkContainer className="linkContainer">
+          <p>
+            <span>자세히</span>
+            보기
+          </p>
           <img src={arrowRight} alt="" />
         </LinkContainer>
       </Article>
@@ -41,11 +45,15 @@ const MainArticle = () => {
         <div>
           <h3>전시 리뷰</h3>
           <p className="card-discription">
-            <span>다양한 전시 리뷰를</span> 찾아보세요
+            <span>다양한</span>
+            <span>전시 리뷰를</span> 찾아보세요
           </p>
         </div>
-        <LinkContainer>
-          <span className="linkContainer">자세히 보기</span>
+        <LinkContainer className="linkContainer">
+          <p>
+            <span>자세히</span>
+            보기
+          </p>
           <img src={arrowRight} alt="" />
         </LinkContainer>
       </Article>
@@ -58,12 +66,15 @@ const MainArticle = () => {
         <div>
           <h3>메이트</h3>
           <p className="card-discription">
-            <span>전시회에 같이 갈</span>
+            <span>전시회에</span>
+            <span>같이 갈</span>
             <span>친구를</span> 찾아보세요
           </p>
         </div>
         <LinkContainer className="linkContainer">
-          <span>자세히 보기</span>
+          <p>
+            <span>자세히</span> 보기
+          </p>
           <img src={arrowRight} alt="" />
         </LinkContainer>
       </Article>
@@ -145,4 +156,10 @@ const LinkContainer = styled.div`
   font-weight: 700;
   font-size: 14px;
   text-decoration: none;
+  p {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 2.5px;
+  }
 `;

--- a/src/components/main/MainArticle.tsx
+++ b/src/components/main/MainArticle.tsx
@@ -28,7 +28,7 @@ const MainArticle = () => {
             <span>전시 정보를</span> 찾아보세요
           </p>
         </div>
-        <LinkContainer className="linkContainer">
+        <LinkContainer>
           <p>
             <span>자세히</span>
             보기
@@ -49,7 +49,7 @@ const MainArticle = () => {
             <span>전시 리뷰를</span> 찾아보세요
           </p>
         </div>
-        <LinkContainer className="linkContainer">
+        <LinkContainer>
           <p>
             <span>자세히</span>
             보기
@@ -71,7 +71,7 @@ const MainArticle = () => {
             <span>친구를</span> 찾아보세요
           </p>
         </div>
-        <LinkContainer className="linkContainer">
+        <LinkContainer>
           <p>
             <span>자세히</span> 보기
           </p>
@@ -125,7 +125,7 @@ const Article = styled.article`
     border: 1px solid ${theme.colors.primry60};
     & h3,
     p,
-    .linkContainer {
+    span {
       color: ${theme.colors.primry80};
     }
   }

--- a/src/components/main/NewCarousel.tsx
+++ b/src/components/main/NewCarousel.tsx
@@ -11,7 +11,14 @@ import thirdSlideImage from "../../assets/images/thirdSlideImage.jpg";
 
 const NewCarousel = () => (
   <CarousalContainer>
-    <Slider dots infinite speed={800} slidesToShow={1} slidesToScroll={1}>
+    <Slider
+      className="slider"
+      dots
+      infinite
+      speed={800}
+      slidesToShow={1}
+      slidesToScroll={1}
+    >
       <SlideCard image={`${firstSlideImage}`}>
         <TextBox>
           <Title>최근 뜨고 있는 전시</Title>
@@ -45,15 +52,35 @@ export default NewCarousel;
 const CarousalContainer = styled.div`
   width: 100vw;
   max-width: 1440px;
-  height: 618px;
+  aspect-ratio: 1/0.42;
   margin: 40px auto 30px auto;
+  .slider {
+    width: 100%;
+    height: 1/0.42;
+    min-height: 400px;
+  }
+  .slick-dots {
+    left: 50%;
+    bottom: 36px;
+    transform: translate(-50%, -50%);
+  }
   @media (max-width: 1440px) {
     padding: 0 20px;
+    .slick-dots {
+      bottom: 20px;
+    }
+  }
+  @media (max-width: 624px) {
+    padding: 0 20px;
+    .slick-dots {
+      bottom: 5px;
+    }
   }
 `;
 
 const SlideCard = styled.div<{ image: string }>`
-  height: 618px;
+  aspect-ratio: 1/0.42;
+  min-height: 400px;
   border-radius: 0px;
   background: linear-gradient(rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.3)),
     url(${(props) => props.image});
@@ -73,6 +100,12 @@ const TextBox = styled.div`
   text-align: center;
   margin-top: 190px;
   font-weight: 500;
+  @media (max-width: 1440px) {
+    margin-top: 13.1vw;
+  }
+  @media (max-width: 1000px) {
+    margin-top: 130px;
+  }
 `;
 
 const Title = styled.h3`
@@ -82,6 +115,9 @@ const Title = styled.h3`
   text-shadow: 0px 0px 20px rgba(56, 30, 114, 0.1);
   color: ${theme.colors.white100};
   opacity: 0.8;
+  @media (max-width: 1440px) {
+    font-size: 24px;
+  }
 `;
 
 const SubTitle = styled.p`
@@ -90,4 +126,16 @@ const SubTitle = styled.p`
   letter-spacing: -1px;
   text-shadow: 0px 0px 20px rgba(56, 30, 114, 0.1);
   color: ${theme.colors.white100};
+  @media (max-width: 1439px) {
+    font-size: 4.7vw;
+    line-height: 5.2vw;
+  }
+  @media (max-width: 1064px) {
+    font-size: 35px;
+    line-height: 45px;
+  }
+  @media (max-width: 624px) {
+    font-size: 30px;
+    line-height: 45px;
+  }
 `;


### PR DESCRIPTION
1. 메인페이지 캐러셀 반응형으로 수정. 화면의 넓이에 따라 비율대로 높이도 줄어듭니다. 하지만 400픽셀 미만으로는 줄어들지 않습니다
   - 글자도 반응형으로 줄어듧니다. 높이가 최소높이인 400픽셀이 될 때는 그 이하로 화면이 줄어도 글자크기가 유지됩니다
   - 페이지수를 나타내는 점들도 가운데를 유지합니다. 기존에는 화면이 작아질때 점들이 약간 오른쪽으로 치우치는 경향이 있었는데, 라이브러리 내의 클래스를 찾아 속성을 변경해주어 가운데를 유지하도록 했습니다.
 2. 메인카드 3개의 크기, 글자크기도 반응형으로 수정.
     - 기존에는 화면이 줄어들어 글자가 밑으로 내려갈 때 한글자씩 내려가서 가독성이 떨어졌었습니다 -> 웹접근성 문제
     - 다양한 / ~~~ / 찾아보세요 설명을 단어단위로 span으로 끊어서 단어단위로 내려가도록 했습니다.
     - 자세히 보기도 마찬가지로 화면이 줄어들때 자세히 보/기 로 끊어지던 부분을 자세히 /보기 로 끊어지도록 했습니다
3. LinkContainer -> SeeMore 자세히보기 링크기능이 사라지고 메인카드 전체에 들어가서, 스타일드 컴포넌트명을 변경했습니다
4. 메인카드들에 호버하면 그림자도 생겨야하는데 없어서 추가했습니다