### PR TITLE
Design: footer 반응형으로 수정

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -38,8 +38,8 @@ const Footer = () => {
             Copyright 2022 © mane. All rights reserved.
           </Copyright>
           <Terms>
-            <span>이용약관</span> | <span>개인정보처리방침</span> |
-            <span> 청소년보호정책</span> |
+            <span>이용약관</span>|<span>개인정보처리방침</span>|
+            <span>청소년보호정책</span>|
             <span>
               <Link
                 href="https://docs.google.com/forms/d/1UX8MuID74mg9afbzWdIfKU1CagQMA_FoXoDqvORx50w/edit"
@@ -61,18 +61,18 @@ const FooterContainer = styled.div`
   display: flex;
   justify-content: start;
   width: 100vw;
-  height: fit-content;
-  min-height: 466px;
+  padding: 120px 0;
   border-radius: 0px;
   background-color: rgba(149, 141, 165, 0.05);
   @media (max-width: 1440px) {
-    padding: 0 20px;
+    padding: 9.3vw 20px;
   }
 `;
 
 const FooterWrapper = styled.div`
+  width: 100%;
   max-width: 1440px;
-  margin: 120px auto 0px auto;
+  margin: auto;
 `;
 
 const TopArea = styled.div`
@@ -82,13 +82,15 @@ const TopArea = styled.div`
 `;
 
 const Developers = styled.div`
+  width: 80%;
   display: flex;
+  justify-content: space-between;
   flex-wrap: wrap;
-  gap: 30px;
+  gap: 10px;
 `;
 
 const JobGroup = styled.div`
-  width: 215px;
+  min-width: 115px;
   font-family: "Roboto";
 `;
 
@@ -99,6 +101,9 @@ const JobTitle = styled.p`
   line-height: 20px;
   letter-spacing: 1px;
   color: ${theme.colors.primry70};
+  @media (max-width: 1064px) {
+    font-size: 16px;
+  }
 `;
 
 const People = styled.p`
@@ -106,6 +111,9 @@ const People = styled.p`
   font-size: 18px;
   line-height: 24px;
   color: ${theme.colors.secondary50};
+  @media (max-width: 1064px) {
+    font-size: 16px;
+  }
 `;
 
 const BottomArea = styled.div`
@@ -117,6 +125,9 @@ const BottomArea = styled.div`
   font-size: 14px;
   line-height: 16px;
   color: ${theme.colors.secondary40};
+  @media (max-width: 1064px) {
+    font-size: 12px;
+  }
 `;
 
 const Copyright = styled.div`
@@ -124,10 +135,13 @@ const Copyright = styled.div`
 `;
 
 const Terms = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
   font-weight: 400;
 `;
 
 const Link = styled.a`
+  color: ${theme.colors.primry80};
   text-decoration: none;
-  color: ${theme.colors.secondary40};
 `;


### PR DESCRIPTION
1. JopGroup의 지정된 넓이를 없애 화면이 줄어들면 글자들 사이의 여백이 줄어들도록 함.
    - 너무 줄어들면 글자가 깨져서 최소 넓이는 지정함. 최소넓이들보다 화면 줄어들면 flex-wrap:wrap 속성으로 아래로 내려감
2. 푸터 위아래 여백을 화면이 줄어들면 그에 맞는 비율로 줄어들게 함. 기본은 원래여백. 줄어들때만 바뀜
3. 화면넓이에 따라 글자크기 반응형으로 줄어듦
4. > 문의하기 < 를 누르면 구글폼으로 이동하는데, 눈에 안띄어서 진한 글씨로 바꿔봄 -> 반영된 후 팀원들 피드백 필요할 듯


이제 화면 줄어들어도 안깨질 거에요!