### PR TITLE
Fix: 블로그리뷰 상세페이지 프로필 이미지 왜곡 수정

### DIFF
--- a/src/components/onelineReview/presentation/MypageOnelineCard.tsx
+++ b/src/components/onelineReview/presentation/MypageOnelineCard.tsx
@@ -164,9 +164,9 @@ const Review = styled.div`
 const ReviewInfo = styled.div`
   & > .exhibition-title {
     color: ${theme.colors.greys90};
-    font-weight: 500;
-    font-size: 14px;
-    line-height: 20px;
+    font-weight: 700;
+    font-size: 16px;
+    line-height: 22px;
   }
   & > img {
     margin-bottom: 10px;

--- a/src/components/onelineReview/presentation/OnelineCard.tsx
+++ b/src/components/onelineReview/presentation/OnelineCard.tsx
@@ -190,6 +190,7 @@ const Review = styled.div`
   gap: 30px;
   & > img {
     width: 86px;
+    border-radius: 100vmax;
     aspect-ratio: 1 / 1;
   }
 `;


### PR DESCRIPTION
프로필이미지 border-radius 수정했습니다

src/components/onelineReview/presentation/OnelineCard.tsx 만 확인하시면 됩니다.