### PR TITLE
Fix/use refresh token

### DIFF
--- a/src/apis/useRefreshToken.tsx
+++ b/src/apis/useRefreshToken.tsx
@@ -31,10 +31,10 @@ const useRefreshTokenApi = () => {
           removeLocalStorageItem();
           alert("자동 로그인 기간이 만료되었습니다. 다시 로그인해주세요.");
           navigate("/login");
-          return undefined;
+          return null;
         }
       }
-    return undefined;
+    return null;
   };
 
   return refreshTokenApi;


### PR DESCRIPTION
return undefined를 return null로 교체했습니다. 
자바스크립트에서 undefined는 메모리가 할당되었으나 자료형이 정해지지 않은 값으로, 주로 var호이스팅 등 자바스크립트 엔진이 값을 부여하기 이전에 사용하는 값이고 프로그래머가 인위적으로 무효한 값을 부여할 때는 null을 주로 사용합니다.  
보다 자세한 내용은 undefined와 null의 차이를 검색해보시면 도움이 될 것 같습니