### PR TITLE
Fix: 블로그 상세리뷰 페이지 전시 타입 표시 수정

### DIFF
--- a/src/components/blogreview/container/BlogReviewDetailContainer.tsx
+++ b/src/components/blogreview/container/BlogReviewDetailContainer.tsx
@@ -16,11 +16,20 @@ interface BlogReviewDetailContainerProps {
     memberImage: string;
   };
   blogReviewId: number;
+  exhibitionInfo: {
+    id: number;
+    title: string;
+    posterUrl: string;
+    duration: string;
+    space: string;
+    type: string;
+  };
 }
 
 const BlogReviewDetailContainer = ({
   id,
   memberInfo,
+  exhibitionInfo,
   blogReviewId,
 }: BlogReviewDetailContainerProps) => {
   const navigate = useNavigate();

--- a/src/components/onelineReview/presentation/MypageOnelineCard.tsx
+++ b/src/components/onelineReview/presentation/MypageOnelineCard.tsx
@@ -90,10 +90,10 @@ const MypageOnelineCard = ({
               <img src={StarIcon} alt="별점" />
             </div>
           ) : null}
-          <div>
-            <span>{viewDate}</span> |<span>{time}</span> |{" "}
+          <DateInfo>
+            <span>{viewDate}</span> | <span>{time}</span> |{" "}
             <span>{congestion}</span>
-          </div>
+          </DateInfo>
           <p>{content}</p>
         </ReviewInfo>
       </Review>
@@ -182,6 +182,16 @@ const ReviewInfo = styled.div`
     color: ${theme.colors.greys90};
     font-weight: 700;
     font-size: 14px;
+  }
+`;
+
+const DateInfo = styled.div`
+  & > span {
+    color: ${theme.colors.greys80};
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 20px;
+    letter-spacing: -0.5px;
   }
 `;
 

--- a/src/pages/BlogReviewDetail.tsx
+++ b/src/pages/BlogReviewDetail.tsx
@@ -22,6 +22,7 @@ const BlogReviewDetail = () => {
     memberImage: "",
     nickname: "",
   };
+  const isMemberId = !!localStorage.getItem("memberId");
 
   if (isLoading) return <div>...loading</div>;
 
@@ -29,11 +30,15 @@ const BlogReviewDetail = () => {
 
   return (
     <Container>
-      <BlogReviewDetailContainer
-        id={data?.exhibitionInfo.id as number}
-        memberInfo={memberInfo}
-        blogReviewId={data?.id as number}
-      />
+      {data && (
+        <BlogReviewDetailContainer
+          id={data?.exhibitionInfo.id}
+          memberInfo={memberInfo}
+          blogReviewId={data?.id}
+          exhibitionInfo={data?.exhibitionInfo}
+        />
+      )}
+      <Divider />
       <div>
         {data && (
           <BlogReviewDetailPresentation
@@ -67,4 +72,8 @@ const Container = styled.div`
   width: 83vw;
   max-width: 1200px;
   margin: 50px auto;
+`;
+
+const Divider = styled.div`
+  margin-bottom: 2rem;
 `;

--- a/src/types/blogReview.d.ts
+++ b/src/types/blogReview.d.ts
@@ -90,5 +90,6 @@ export interface BlogReviewDetailResponse {
     posterUrl: string;
     duration: string;
     space: string;
+    type: string;
   };
 }


### PR DESCRIPTION
전시 타입 표시 추가
이제 홈페이지에서 전시리뷰로 넘어가도 로그인하지 않은 채 전시회 정보카드를 확인할 수 있습니다