### PR TITLE
Feat: 한줄리뷰 작성, 수정 토큰처리 및 유효성검사

### DIFF
--- a/src/components/atom/SimpleInput.tsx
+++ b/src/components/atom/SimpleInput.tsx
@@ -40,7 +40,7 @@ interface InputProps {
 const InputLegnth = styled.div<InputProps>`
   position: absolute;
   top: 50%;
-  right: 10px;
+  right: 5%;
   transform: translateY(-50%);
   color: ${(props) =>
     props.inputlength > 60 ? theme.colors.error : theme.colors.greys60};

--- a/src/components/onelineReview/container/OnelineModifyContainer.tsx
+++ b/src/components/onelineReview/container/OnelineModifyContainer.tsx
@@ -203,6 +203,7 @@ const OnelineModifyContainer = ({
     }) => oneLineReviewApis.updateReview(reviewId, payload),
     onSuccess: () => {
       queryClient.invalidateQueries(["simpleReviews"]);
+      handleModal();
     },
   });
 
@@ -210,25 +211,28 @@ const OnelineModifyContainer = ({
     const body = getPayload(id as string, state);
 
     if (Object.values(body).includes("") || Object.values(body).includes(0)) {
-      throw Error("빈 칸으로 남겨진 값이 있습니다.");
+      return alert("빈 칸으로 남겨진 값이 있습니다.");
     }
-    if (body.content.length < 10) alert("본문 내용이 너무 짧습니다");
+    if (body.content.length < 10) return alert("본문 내용이 너무 짧습니다");
+    if (body.content.length >= 60) return alert("본문 내용이 너무 깁니다");
 
+    const reviewId = simpleId;
+    const payload = {
+      viewDate: body.viewDate,
+      time: body.time,
+      congestion: body.congestion,
+      rate: body.rate,
+      content: body.content,
+    };
     try {
-      const reviewId = simpleId;
-      const payload = {
-        viewDate: body.viewDate,
-        time: body.time,
-        congestion: body.congestion,
-        rate: body.rate,
-        content: body.content,
-      };
       modifyMutation.mutate({ reviewId, payload });
       handleModal();
     } catch (err) {
       const errResponese = isApiError(err);
       if (errResponese === "accessToken 만료") refreshTokenApi();
+      modifyMutation.mutate({ reviewId, payload });
     }
+    return null;
   };
 
   return (

--- a/src/components/onelineReview/container/OnelineModifyContainer.tsx
+++ b/src/components/onelineReview/container/OnelineModifyContainer.tsx
@@ -203,6 +203,7 @@ const OnelineModifyContainer = ({
     }) => oneLineReviewApis.updateReview(reviewId, payload),
     onSuccess: () => {
       queryClient.invalidateQueries(["simpleReviews"]);
+      alert("리뷰 수정에 성공했습니다!");
       handleModal();
     },
   });

--- a/src/components/onelineReview/container/OnelineWriteContainer.tsx
+++ b/src/components/onelineReview/container/OnelineWriteContainer.tsx
@@ -191,6 +191,7 @@ const OnelineWriteContainer = ({
     mutationFn: (payload: Payload) => oneLineReviewApis.createReview(payload),
     onSuccess: () => {
       queryClient.invalidateQueries(["simpleReviews"]);
+      alert("리뷰 등록에 성공했습니다!");
       handleModal();
     },
   });

--- a/src/components/onelineReview/container/OnelineWriteContainer.tsx
+++ b/src/components/onelineReview/container/OnelineWriteContainer.tsx
@@ -191,25 +191,7 @@ const OnelineWriteContainer = ({
     mutationFn: (payload: Payload) => oneLineReviewApis.createReview(payload),
     onSuccess: () => {
       queryClient.invalidateQueries(["simpleReviews"]);
-    },
-  });
-
-  const modifyMutation = useMutation({
-    mutationFn: ({
-      reviewId,
-      payload,
-    }: {
-      reviewId: number;
-      payload: {
-        viewDate: string;
-        time: string;
-        congestion: string;
-        rate: number;
-        content: string;
-      };
-    }) => oneLineReviewApis.updateReview(reviewId, payload),
-    onSuccess: () => {
-      queryClient.invalidateQueries(["simpleReviews"]);
+      handleModal();
     },
   });
 
@@ -217,35 +199,19 @@ const OnelineWriteContainer = ({
     const body = getPayload(id as string, state);
 
     if (Object.values(body).includes("") || Object.values(body).includes(0)) {
-      throw Error("빈 칸으로 남겨진 값이 있습니다.");
+      return alert("빈 칸으로 남겨진 값이 있습니다.");
     }
-    if (body.content.length < 10) alert("본문 내용이 너무 짧습니다");
+    if (body.content.length < 10) return alert("본문 내용이 너무 짧습니다");
+    if (body.content.length >= 60) return alert("본문 내용이 너무 깁니다");
 
-    if (writeType === "create") {
-      try {
-        newReviewMutation.mutate(body);
-        handleModal();
-      } catch (err) {
-        const errResponese = isApiError(err);
-        if (errResponese === "accessToken 만료") refreshTokenApi();
-      }
-    } else if (writeType === "modify") {
-      try {
-        const reviewId = simpleId;
-        const payload = {
-          viewDate: body.viewDate,
-          time: body.time,
-          congestion: body.congestion,
-          rate: body.rate,
-          content: body.content,
-        };
-        modifyMutation.mutate({ reviewId, payload });
-        handleModal();
-      } catch (err) {
-        const errResponese = isApiError(err);
-        if (errResponese === "accessToken 만료") refreshTokenApi();
-      }
+    try {
+      newReviewMutation.mutate(body);
+    } catch (err) {
+      const errResponese = isApiError(err);
+      if (errResponese === "accessToken 만료") refreshTokenApi();
+      newReviewMutation.mutate(body);
     }
+    return null;
   };
 
   return (


### PR DESCRIPTION
- 한줄리뷰 60자 이상 작성시 알림과 함께 제출하지 못하도록 수정
- 인풋창의 레이아웃 문제는 일단 px => %의 상대값으로 전환했습니다.
- 액세스 토큰 처리 추가 
  - 이 부분 현재 구조로는 에러처리의 주도권을 react와 react-query가 공유하고 있어 문제가 발생할 수 있습니다. 차후 컴포넌트단에서 토큰을 취급하지 않아도 되도록 구조개선 예정입니다.