### PR TITLE
Fix: 블로그리뷰 작성페이지 달력 2번클릭해야 날짜 반영되는 오류 수정

### DIFF
--- a/src/pages/BlogReviewModify.tsx
+++ b/src/pages/BlogReviewModify.tsx
@@ -328,6 +328,9 @@ const BlogReviewUpdate = () => {
             <SubTitle text="관람일" />
             <Calender
               selectedDate={new Date()}
+              // selectedDate={new Date(selectedDate)}
+              // 수정페이지일 때도 마찬가지로 selectedDate를 넘겨줘야 하는데,
+              // 현재 수정모드일 때 기존에 선택된 날짜를 어떻게 받아오고 계신지 모르겠어서 일단 그대로 남겨둡니다.-예선
               handleSelectedDate={setSelectedDate}
             />
           </div>

--- a/src/pages/BlogReviewWrite.tsx
+++ b/src/pages/BlogReviewWrite.tsx
@@ -2,6 +2,7 @@ import React, { useState, ChangeEvent, useReducer, useEffect } from "react";
 import styled from "styled-components";
 import { useMutation } from "react-query";
 import { useLocation, useNavigate } from "react-router-dom";
+import { format } from "date-fns";
 import ReviewTitle from "../components/blogreview/ReviewTitle";
 import ExhibitionSelect from "../components/blogreview/ExhibitionSelect";
 import Calender from "../components/Calendar";
@@ -143,7 +144,9 @@ import useRefreshTokenApi from "../apis/useRefreshToken";
 const BlogReviewWrite = () => {
   // const [state, dispatch] = useReducer(reducer, initialState);
   const [title, setTitle] = useState("");
-  const [selectedDate, setSelectedDate] = useState("");
+  const [selectedDate, setSelectedDate] = useState(
+    format(new Date(), "yyyy-MM-dd")
+  );
   const [enterTime, setEnterTime] = useState("");
   const [exitTime, setExitTime] = useState("");
   const [congestion, setCongestion] = useState("");
@@ -284,6 +287,8 @@ const BlogReviewWrite = () => {
       }
     } else {
       alert("빈 칸으로 남겨진 데이터를 입력해주세요.");
+      // 사용자 입장에선 빈 칸으로 남겨진 데이터가 없게 보이는데도 이렇게 떠서
+      // 좀 더 구체적인 안내가 필요할 듯 합니다.-예선
     }
   };
 
@@ -300,7 +305,9 @@ const BlogReviewWrite = () => {
           <div>
             <SubTitle text="관람일" />
             <Calender
-              selectedDate={new Date()}
+              selectedDate={new Date(selectedDate)}
+              // 왜 이렇게 들어가야 하는지 헷갈리시면
+              // 메이트글 작성/수정 페이지 컴포넌트인 src-pages-MateWrite.tsx 파일 참고부탁드립니다 - 예선
               handleSelectedDate={setSelectedDate}
             />
           </div>


### PR DESCRIPTION
1. 블로그리뷰 작성할 때 달력을 2번클릭해야 날짜가 반영되는 오류를 수정했습니다.

제가 달력컴포넌트에 기존날짜 넘겨주는 로직을 수정하면서 에러가 안나도록 임시로 현재 날짜를 넘겨주도록 했는데,
주석으로 설명을 달아놓지 않아서 동규님께서 헷갈리신 것 같습니다. 다음엔 공통 컴포넌트 수정 시 더 자세하게 작성해두겠습니다:)

달력컴포넌트 props인 selectedDate는 현재 날짜가 아닌 사용자가 선택한 것이 반영되는 유동적인 날짜를 부여해주셔야 합니다. 

‼️ 블로그리뷰 수정페이지는 컴포넌트가 다르던데 아직 완성이 안된것 같아보여 주석만 추가했습니다. 동규님께서 수정부탁드려요
동규님이 확인해주시면 머지할게요~