### PR TITLE
Design: 메이트글 상세페이지 보라색박스 영역 반응형 추가

### DIFF
--- a/src/components/mate/CommentList.tsx
+++ b/src/components/mate/CommentList.tsx
@@ -8,7 +8,7 @@ interface CommentListType {
   setCommentTextArea: React.Dispatch<React.SetStateAction<string>>;
 }
 
-// 댓글 목록, 작성란 컴포넌트_박예선_23.02.10
+// 댓글 목록, 작성란 컴포넌트_박예선_23.02.15
 const CommentList = (props: CommentListType) => {
   const { commentTextArea, setCommentTextArea } = props;
   const memberNickname = localStorage.getItem("nickname");
@@ -66,6 +66,9 @@ const CommentListContainer = styled.div`
     span {
       color: ${theme.colors.primry60};
     }
+  }
+  @media (max-width: 624px) {
+    padding: 20px;
   }
 `;
 

--- a/src/pages/Mate.tsx
+++ b/src/pages/Mate.tsx
@@ -19,7 +19,7 @@ import CommentList, {
   TextArea,
 } from "../components/mate/CommentList";
 
-// 메이트 모집글 상세페이지_박예선_23.02.10
+// 메이트 모집글 상세페이지_박예선_23.02.14
 const Mate = () => {
   const navigate = useNavigate();
   const mateBookMarkApi = useMateBookMarkApi();
@@ -103,7 +103,7 @@ const Mate = () => {
               </div>
             </div>
           </div>
-          <div className="flex">
+          <ColoredBoxContainer>
             <ColoredBox>
               <Icon src={calendar} alt="달력 아이콘" />
               <div>
@@ -125,7 +125,7 @@ const Mate = () => {
                 <span>{mateInfo.mateAge}</span>
               </div>
             </ColoredBox>
-          </div>
+          </ColoredBoxContainer>
           <div>
             <SubTitle type="greys90" marginTop={50}>
               메이트 설명글
@@ -254,6 +254,9 @@ const MateContentContainer = styled.div`
     display: flex;
     margin-top: 50px;
   }
+  @media (max-width: 624px) {
+    padding: 20px;
+  }
 `;
 
 const Title = styled.div<{
@@ -269,9 +272,16 @@ const Title = styled.div<{
   line-height: ${(props) => `${props.lineHight}px`};
 `;
 
+const ColoredBoxContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: start;
+  gap: 10px 2vw;
+  margin-top: 50px;
+`;
+
 const ColoredBox = styled.div`
   display: flex;
-  margin: 50px 30px 0 0;
   padding: 30px;
   background-color: ${theme.colors.secondary5};
   border-radius: 16px;
@@ -290,7 +300,6 @@ const ColoredBox = styled.div`
     line-height: 22px;
   }
   @media (max-width: 1440px) {
-    margin-right: 2.08vw;
     padding: 2.08vw;
     h4,
     span {
@@ -298,7 +307,7 @@ const ColoredBox = styled.div`
     }
   }
   @media (max-width: 1064px) {
-    padding: 15px;
+    padding: 22px;
   }
   @media (max-width: 624px) {
     h4,


### PR DESCRIPTION
메이트글 상세페이지를 모바일에서 봤을 때 보라색 박스 부분의 레이아웃이 깨져보이는 것을 수정했습니다.
피그마에 반응형으로 기재되어있는 디자인은 아니지만 모바일에서 깨지지 않도록 임시로 수정했습니다.
머지 후 전체 팀원에게 고지하고, 변경할 부분이 생기면 그때 다시 변경할게요!
지금은 레이아웃이 깨지지 않게 하기 위한 것을 우선으로 잡았습니다.

작업내용
1. 박스세개를 감싸는 컨테이너에 flex-wrap: wrap을 부여해 크기가 넘칠 시 박스가 아래로 내려가도록 했습니다.
2. 미디어 쿼리로 넓이에 따라 부여하던 패딩값을 더 자연스럽게 변경했습니다
(화면넓이에 따라 확확바뀌는게 아니라 연결되며 바뀌도록 보이게 함)
3. 메이트글 상세페이지의 댓글 영역의 패딩도 본문 영역의 패딩과 동일하게 변경되도록 했습니다

➡️ 변경 전
<img width="462" alt="무제" src="https://user-images.githubusercontent.com/108933466/218958624-5f116a25-1e87-461a-a206-2cfed24f9bb8.png">
➡️ 변경 후
<img width="462" alt="무제" src="https://user-images.githubusercontent.com/108933466/218959421-f8214b47-64b0-4b31-a766-c601621d6057.png">

