### PR TITLE
Design: 메이트글 상세페이지, 블로그리뷰 상세페이지 전시회 카드영역 반응형 추가

### DIFF
--- a/src/components/mate/CommentList.tsx
+++ b/src/components/mate/CommentList.tsx
@@ -8,7 +8,7 @@ interface CommentListType {
   setCommentTextArea: React.Dispatch<React.SetStateAction<string>>;
 }
 
-// 댓글 목록, 작성란 컴포넌트_박예선_23.02.10
+// 댓글 목록, 작성란 컴포넌트_박예선_23.02.15
 const CommentList = (props: CommentListType) => {
   const { commentTextArea, setCommentTextArea } = props;
   const memberNickname = localStorage.getItem("nickname");
@@ -66,6 +66,9 @@ const CommentListContainer = styled.div`
     span {
       color: ${theme.colors.primry60};
     }
+  }
+  @media (max-width: 624px) {
+    padding: 20px;
   }
 `;
 

--- a/src/components/mate/ExhbCard.tsx
+++ b/src/components/mate/ExhbCard.tsx
@@ -14,7 +14,7 @@ interface ExhbCardType {
   };
 }
 
-// 메이트 모집글 전시회 카드컴포넌트_박예선_23.02.12
+// 메이트 모집글 전시회 카드컴포넌트_박예선_23.02.15
 const ExhbCard = (props: ExhbCardType) => {
   const { exhbData } = props;
   const {
@@ -45,7 +45,7 @@ const ExhbCard = (props: ExhbCardType) => {
         alt="thumbnail"
       />
       <InfoContainer>
-        <div className="title">{exhibitionTitle}</div>
+        <Title className="title">{exhibitionTitle}</Title>
         <DetailContainer>
           <Detail>
             <div className="detail-name">일정</div>
@@ -78,6 +78,9 @@ const ExhbCardContainer = styled.div`
   .flex {
     display: flex;
   }
+  @media (max-width: 370px) {
+    flex-direction: column;
+  }
 `;
 
 const Thumbnail = styled.img<{ height: number }>`
@@ -89,6 +92,13 @@ const Thumbnail = styled.img<{ height: number }>`
   @media (max-width: 624px) {
     width: 40%;
   }
+  @media (max-width: 370px) {
+    width: inherit;
+    height: 150px;
+    border-top-right-radius: 30px;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+  }
 `;
 
 const InfoContainer = styled.div`
@@ -96,12 +106,30 @@ const InfoContainer = styled.div`
   flex-direction: column;
   width: 100%;
   padding: 30px;
-  .title {
-    margin-bottom: 30px;
-    color: ${(props) => props.theme.colors.greys90};
-    font-size: 42px;
-    font-weight: 700;
-    line-height: 52px;
+  @media (max-width: 1440px) {
+    padding: 20px;
+  }
+  @media (max-width: 1072px) {
+    padding: 16px;
+  }
+`;
+
+const Title = styled.div`
+  margin-bottom: 30px;
+  color: ${(props) => props.theme.colors.greys90};
+  font-size: 42px;
+  font-weight: 700;
+  line-height: 52px;
+  @media (max-width: 1440px) {
+    font-size: 2.9vw;
+    line-height: 3.61vw;
+  }
+  @media (max-width: 690px) {
+    font-size: 20px;
+    line-height: 30px;
+  }
+  @media (max-width: 370px) {
+    margin-bottom: 10px;
   }
 `;
 
@@ -109,6 +137,9 @@ const DetailContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 10px;
+  @media (max-width: 370px) {
+    gap: 0;
+  }
 `;
 
 const Detail = styled.div`
@@ -123,5 +154,10 @@ const Detail = styled.div`
     width: 72px;
     margin-right: 30px;
     color: ${theme.colors.greys60};
+  }
+  @media (max-width: 624px) {
+    .detail-name {
+      margin-right: 5px;
+    }
   }
 `;

--- a/src/components/mate/MateTop.tsx
+++ b/src/components/mate/MateTop.tsx
@@ -12,7 +12,7 @@ interface MateTopType {
   mateInfo: MateRes;
 }
 
-// 메이트 상세페이지 상단 배경색 있는 부분 컴포넌트_박예선_23.02.10
+// 메이트 상세페이지 상단 배경색 있는 부분 컴포넌트_박예선_23.02.15
 const MateTop = (props: MateTopType) => {
   const { isMyPost, mateId, mateInfo } = props;
   const navigate = useNavigate();
@@ -64,7 +64,10 @@ const MateTopContainer = styled.div`
     padding: 50px 20px;
   }
   @media (max-width: 1072px) {
-    padding: 50px 16px;
+    padding: 4.6vw 16px;
+  }
+  @media (max-width: 347px) {
+    padding: 16px;
   }
 `;
 

--- a/src/pages/Mate.tsx
+++ b/src/pages/Mate.tsx
@@ -19,7 +19,7 @@ import CommentList, {
   TextArea,
 } from "../components/mate/CommentList";
 
-// 메이트 모집글 상세페이지_박예선_23.02.10
+// 메이트 모집글 상세페이지_박예선_23.02.14
 const Mate = () => {
   const navigate = useNavigate();
   const mateBookMarkApi = useMateBookMarkApi();
@@ -103,7 +103,7 @@ const Mate = () => {
               </div>
             </div>
           </div>
-          <div className="flex">
+          <ColoredBoxContainer>
             <ColoredBox>
               <Icon src={calendar} alt="달력 아이콘" />
               <div>
@@ -125,7 +125,7 @@ const Mate = () => {
                 <span>{mateInfo.mateAge}</span>
               </div>
             </ColoredBox>
-          </div>
+          </ColoredBoxContainer>
           <div>
             <SubTitle type="greys90" marginTop={50}>
               메이트 설명글
@@ -254,6 +254,9 @@ const MateContentContainer = styled.div`
     display: flex;
     margin-top: 50px;
   }
+  @media (max-width: 624px) {
+    padding: 20px;
+  }
 `;
 
 const Title = styled.div<{
@@ -269,9 +272,16 @@ const Title = styled.div<{
   line-height: ${(props) => `${props.lineHight}px`};
 `;
 
+const ColoredBoxContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: start;
+  gap: 10px 2vw;
+  margin-top: 50px;
+`;
+
 const ColoredBox = styled.div`
   display: flex;
-  margin: 50px 30px 0 0;
   padding: 30px;
   background-color: ${theme.colors.secondary5};
   border-radius: 16px;
@@ -290,7 +300,6 @@ const ColoredBox = styled.div`
     line-height: 22px;
   }
   @media (max-width: 1440px) {
-    margin-right: 2.08vw;
     padding: 2.08vw;
     h4,
     span {
@@ -298,7 +307,7 @@ const ColoredBox = styled.div`
     }
   }
   @media (max-width: 1064px) {
-    padding: 15px;
+    padding: 22px;
   }
   @media (max-width: 624px) {
     h4,

--- a/src/pages/Mate.tsx
+++ b/src/pages/Mate.tsx
@@ -19,7 +19,7 @@ import CommentList, {
   TextArea,
 } from "../components/mate/CommentList";
 
-// 메이트 모집글 상세페이지_박예선_23.02.14
+// 메이트 모집글 상세페이지_박예선_23.02.15
 const Mate = () => {
   const navigate = useNavigate();
   const mateBookMarkApi = useMateBookMarkApi();
@@ -254,8 +254,14 @@ const MateContentContainer = styled.div`
     display: flex;
     margin-top: 50px;
   }
+  @media (max-width: 1072px) {
+    margin: 4.6vw 0 30px;
+  }
   @media (max-width: 624px) {
     padding: 20px;
+  }
+  @media (max-width: 347px) {
+    margin: 16px 0;
   }
 `;
 


### PR DESCRIPTION
메이트글 상세페이지의 전시회 카드부분이 모바일크기에서는 레이아웃이 많이 깨져 수정했습니다.(블로그리뷰 상세페이지도 동일)
이 부분도 임시로 깨지지않게만 해둔거고, 피드백 들어오면 또 수정될 수 있습니다

1. 넓이에 따라 글자크기, line-height, 제목과 장소, 일정, 상태 라벨사이 간격 변경(일정 크기 이하로 줄어들진 않음)
2. 370이하로 내려가면 또 깨지기 때문에 그 이하일 때는 이미지가 왼쪽이 아닌 위쪽으로 배치되도록 수정

<div style="flex">
🔥 변경 전
<img width="100" alt="1" src="https://user-images.githubusercontent.com/108933466/218979309-4b5ab29b-3997-4105-b9fb-eb1960861131.png">
🔥 변경 후
<img width="100" alt="무제" src="https://user-images.githubusercontent.com/108933466/218982126-7fef13f2-e3c6-4518-bb7d-f7a7bb24d055.png">
🔥 변경 후(370픽셀 이하)
<img width="100" alt="3" src="https://user-images.githubusercontent.com/108933466/218982322-ed5e7ce2-789a-483c-80c8-245600b958bd.png">


</div >