### PR TITLE
Refactor: 전시회 카드 컴포넌트에 useEffect 클린업 콜백 추가

### DIFF
--- a/src/components/mate/ExhbCard.tsx
+++ b/src/components/mate/ExhbCard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
+import { clearTimeout } from "timers";
 import { theme } from "../../styles/theme";
 
 interface ExhbCardType {
@@ -30,10 +31,14 @@ const ExhbCard = (props: ExhbCardType) => {
 
   // 제목의 높이에 따라 썸네일 높이 변경_박예선_23.02.12
   useEffect(() => {
-    setTimeout(() => {
+    const heightTimeout = setTimeout(() => {
       const height = document.querySelector(".title")?.clientHeight;
       setThumbnailHeight(height! + 190);
     }, 100);
+
+    return () => {
+      clearTimeout(heightTimeout);
+    };
   }, []);
 
   return (

--- a/src/components/mate/ExhbCard.tsx
+++ b/src/components/mate/ExhbCard.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
-import { clearTimeout } from "timers";
 import { theme } from "../../styles/theme";
 
 interface ExhbCardType {


### PR DESCRIPTION
둘러보다가 setTimeout을 발견해서 useEffect 콜백을 추가했습니다.  
리액트의 경우 useEffect내부에 setTimeout, setInterval을 설정해두면 컴포넌트가 언마운트 되더라도 타이머는 그대로 남아있습니다. 별다른 부작용은 없어보이지만 일단 클린업 했습니다. 

자세히 설명하자면 setInterval로 카운터를 만들어보면 알기 쉬운데 1초마다 하나씩 증가하는 카운터를 만들었을 때 클린업하지 않으면 언마운트 -> 리마운트되었을 때 1초에 2씩 증가하게 됩니다. strict모드에서 컴포넌트가 두 번씩 마운팅 되는 것도 이런 눈치채기 어려운 버그를 탐지하기 위한 로직입니다.