### PR TITLE
Fix: 전시회 목록 정렬 필터 인기순-> 조회수순으로 변경, 기능 추가 + api 수정됨

### DIFF
--- a/src/apis/getExhbList.tsx
+++ b/src/apis/getExhbList.tsx
@@ -18,12 +18,6 @@ const exhbListApi = async (
   type: FilterType,
   page: number
 ) => {
-  if (type === "전체 전시") {
-    const res: AxiosResponse<ExhbListRes> = await apiInstance.get(
-      `/main/exhibitions/?status=${status} 전시&page=${page}`
-    );
-    return res;
-  }
   const res: AxiosResponse<ExhbListRes> = await apiInstance.get(
     `/exhibitions/?status=${status} 전시&type=${type}&page=${page}`
   );

--- a/src/apis/getExhbList.tsx
+++ b/src/apis/getExhbList.tsx
@@ -19,7 +19,7 @@ const exhbListApi = async (
   page: number
 ) => {
   const res: AxiosResponse<ExhbListRes> = await apiInstance.get(
-    `/exhibitions/?status=${status} 전시&type=${type}&page=${page}&sort=최신순`
+    `/exhibitions/?status=${status} 전시&type=${type}&sort=최신순&page=${page}`
   );
   // 임시로 sort 최신순 추가. selectBox 인기순에서 조회수순으로 바꾸고 기능 추가후 반영하기
   return res;

--- a/src/apis/getExhbList.tsx
+++ b/src/apis/getExhbList.tsx
@@ -16,6 +16,7 @@ export interface ExhbListRes {
 const exhbListApi = async (
   status: StatusType,
   type: FilterType,
+  // sort:
   page: number
 ) => {
   const res: AxiosResponse<ExhbListRes> = await apiInstance.get(

--- a/src/apis/getExhbList.tsx
+++ b/src/apis/getExhbList.tsx
@@ -1,6 +1,6 @@
 import { AxiosResponse } from "axios";
 import { StatusType } from "../components/exhibitionList/Filters";
-import { Exhibition, FilterType } from "../types/exhbList";
+import { Exhibition, FilterType, SortType } from "../types/exhbList";
 import apiInstance from "../utils/apiInstance";
 
 export interface ExhbListRes {
@@ -16,13 +16,12 @@ export interface ExhbListRes {
 const exhbListApi = async (
   status: StatusType,
   type: FilterType,
-  // sort:
+  sort: SortType,
   page: number
 ) => {
   const res: AxiosResponse<ExhbListRes> = await apiInstance.get(
-    `/exhibitions/?status=${status} 전시&type=${type}&sort=최신순&page=${page}`
+    `/exhibitions/?status=${status} 전시&type=${type}&sort=${sort}&page=${page}`
   );
-  // 임시로 sort 최신순 추가. selectBox 인기순에서 조회수순으로 바꾸고 기능 추가후 반영하기
   return res;
 };
 

--- a/src/apis/getExhbList.tsx
+++ b/src/apis/getExhbList.tsx
@@ -19,8 +19,9 @@ const exhbListApi = async (
   page: number
 ) => {
   const res: AxiosResponse<ExhbListRes> = await apiInstance.get(
-    `/exhibitions/?status=${status} 전시&type=${type}&page=${page}`
+    `/exhibitions/?status=${status} 전시&type=${type}&page=${page}&sort=최신순`
   );
+  // 임시로 sort 최신순 추가. selectBox 인기순에서 조회수순으로 바꾸고 기능 추가후 반영하기
   return res;
 };
 

--- a/src/components/ExhibitionChoice.tsx
+++ b/src/components/ExhibitionChoice.tsx
@@ -39,7 +39,9 @@ const ExhibitionChoice = ({ getExhbInfo, handleModal }: ChoiceProps) => {
   const { isLoading, isError, error, data } = useQuery<ExhbListRes, Error>({
     queryKey: ["exhbList", { pageInfo, exhbStatus }],
     queryFn: () =>
-      exhbListApi(exhbStatus, "전체 전시", pageInfo).then((res) => res.data),
+      exhbListApi(exhbStatus, "전체 전시", "최신순", pageInfo).then(
+        (res) => res.data
+      ),
   });
   // 파일 체인지를 확인하기 위한 쓸데없는 주석입니다
 

--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -19,12 +19,13 @@ const Filters = (props: FiltersType) => {
     setSelectedStatus(status);
   };
 
-  // 필터 조건 핸들 함수_박예선_23.02.01
+  // 필터 조건 핸들 함수_박예선_23.02.24
   const handleFilters = (e: React.MouseEvent<HTMLLIElement>) => {
     const value = e.currentTarget.textContent;
     if (!value) return;
-    if (value === "인기순") {
+    if (value === "조회수순") {
       alert("준비중인 기능입니다.");
+      // 기능 추후 추가하기. api 준비되어있음.
       return;
     }
     for (let i = 0; i < EXHB_TYPE_ARRAY.length; i += 1) {
@@ -81,7 +82,7 @@ const Filters = (props: FiltersType) => {
 export default Filters;
 
 const EXHB_STATUS_ARRAY: StatusType[] = ["현재", "예정", "지난"];
-const EXHB_SORT_ARRAY = ["최신순", "인기순"];
+const EXHB_SORT_ARRAY = ["최신순", "조회수순"];
 export const EXHB_TYPE_ARRAY: FilterType[] = [
   "전체 전시",
   "영상 전시",

--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -6,12 +6,17 @@ import SearchInput from "../atom/SearchInput";
 import Selectbox from "../atom/Selectbox";
 import { PagesState } from "../Pagination";
 import { alertPreparing } from "../../utils/alerts";
-import { FilterType } from "../../types/exhbList";
+import { FilterType, SortType } from "../../types/exhbList";
 
-// 전시글 목록 상단 필터 컴포넌트_박예선_23.02.08
+// 전시글 목록 상단 필터 컴포넌트_박예선_23.02.24
 const Filters = (props: FiltersType) => {
-  const { setPages, selectedStatus, setSelectedStatus, setSelectedFilter } =
-    props;
+  const {
+    setPages,
+    selectedStatus,
+    setSelectedStatus,
+    selectedFilter,
+    setSelectedFilter,
+  } = props;
 
   // 전시상황 버튼 클릭 함수_박예선_23.02.01
   const handleStatusBtn = (status: StatusType) => {
@@ -23,14 +28,14 @@ const Filters = (props: FiltersType) => {
   const handleFilters = (e: React.MouseEvent<HTMLLIElement>) => {
     const value = e.currentTarget.textContent;
     if (!value) return;
-    if (value === "조회수순") {
-      alert("준비중인 기능입니다.");
-      // 기능 추후 추가하기. api 준비되어있음.
-      return;
+    for (let i = 0; i < EXHB_SORT_ARRAY.length; i += 1) {
+      if (value === EXHB_SORT_ARRAY[i]) {
+        setSelectedFilter({ ...selectedFilter, sort: value });
+      }
     }
     for (let i = 0; i < EXHB_TYPE_ARRAY.length; i += 1) {
       if (value === EXHB_TYPE_ARRAY[i]) {
-        setSelectedFilter(value);
+        setSelectedFilter({ ...selectedFilter, type: value });
       }
     }
   };
@@ -82,7 +87,7 @@ const Filters = (props: FiltersType) => {
 export default Filters;
 
 const EXHB_STATUS_ARRAY: StatusType[] = ["현재", "예정", "지난"];
-const EXHB_SORT_ARRAY = ["최신순", "조회수순"];
+const EXHB_SORT_ARRAY: SortType[] = ["최신순", "조회수순"];
 const EXHB_TYPE_ARRAY: FilterType[] = [
   "전체 전시",
   "영상 전시",
@@ -96,7 +101,16 @@ interface FiltersType {
   setPages: React.Dispatch<React.SetStateAction<PagesState>>;
   selectedStatus: StatusType;
   setSelectedStatus: React.Dispatch<React.SetStateAction<StatusType>>;
-  setSelectedFilter: React.Dispatch<React.SetStateAction<FilterType>>;
+  selectedFilter: {
+    type: FilterType;
+    sort: SortType;
+  };
+  setSelectedFilter: React.Dispatch<
+    React.SetStateAction<{
+      type: FilterType;
+      sort: SortType;
+    }>
+  >;
 }
 export type StatusType = "현재" | "예정" | "지난";
 

--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -83,7 +83,7 @@ export default Filters;
 
 const EXHB_STATUS_ARRAY: StatusType[] = ["현재", "예정", "지난"];
 const EXHB_SORT_ARRAY = ["최신순", "조회수순"];
-export const EXHB_TYPE_ARRAY: FilterType[] = [
+const EXHB_TYPE_ARRAY: FilterType[] = [
   "전체 전시",
   "영상 전시",
   "특별 전시",

--- a/src/pages/ExhibitionList.tsx
+++ b/src/pages/ExhibitionList.tsx
@@ -2,30 +2,39 @@ import React, { useCallback, useEffect, useState } from "react";
 import { AxiosResponse } from "axios";
 import styled from "styled-components";
 import { theme } from "../styles/theme";
-import { Exhibition, FilterType } from "../types/exhbList";
+import { Exhibition, FilterType, SortType } from "../types/exhbList";
 import exhbListApi, { ExhbListRes } from "../apis/getExhbList";
 import Pagination from "../components/Pagination";
 import Filters, { StatusType } from "../components/exhibitionList/Filters";
 import ExhbCardList from "../components/exhibitionList/ExhbCardList";
 
-// 전시회 목록 페이지 컴포넌트_박예선_23.02.10
+// 전시회 목록 페이지 컴포넌트_박예선_23.02.24
 const ExhibitionList = () => {
   const [exhbList, setExhbList] = useState<Exhibition[]>([]);
   const [totalPage, setTotalPage] = useState<number>(0);
   const [selectedStatus, setSelectedStatus] = useState<StatusType>("현재");
-  const [selectedFilter, setSelectedFilter] = useState<FilterType>("전체 전시");
+  const [selectedFilter, setSelectedFilter] = useState<{
+    type: FilterType;
+    sort: SortType;
+  }>({ type: "전체 전시", sort: "최신순" });
   const [pages, setPages] = useState({
     started: 1,
     selected: 1,
   });
 
-  // 전시회 목록 요청 api_박예선_23.01.18
+  // 전시회 목록 요청 api_박예선_23.01.24
   const getExhbList = useCallback(
-    async (status: StatusType, type: FilterType, page: number) => {
+    async (
+      status: StatusType,
+      type: FilterType,
+      sort: SortType,
+      page: number
+    ) => {
       try {
         const res: AxiosResponse<ExhbListRes> = await exhbListApi(
           status,
           type,
+          sort,
           page
         );
         const { exhibitions, pageInfo } = res.data;
@@ -40,9 +49,14 @@ const ExhibitionList = () => {
     []
   );
 
-  // 전시상태, 전시유형 필터, 페이지 번호에 따라 전시목록 불러오는 로직_박예선_23.02.01
+  // 전시상태, 전시유형 필터, 페이지 번호에 따라 전시목록 불러오는 로직_박예선_23.02.24
   useEffect(() => {
-    getExhbList(selectedStatus, selectedFilter, pages.selected);
+    getExhbList(
+      selectedStatus,
+      selectedFilter.type,
+      selectedFilter.sort,
+      pages.selected
+    );
   }, [getExhbList, selectedStatus, selectedFilter, pages.selected]);
 
   return (
@@ -54,6 +68,7 @@ const ExhibitionList = () => {
         selectedStatus={selectedStatus}
         setSelectedStatus={setSelectedStatus}
         setPages={setPages}
+        selectedFilter={selectedFilter}
         setSelectedFilter={setSelectedFilter}
       />
       <ExhbCardList exhbList={exhbList} type="exhbList" />

--- a/src/types/exhbList.d.ts
+++ b/src/types/exhbList.d.ts
@@ -16,3 +16,5 @@ export type FilterType =
   | "기획 전시"
   | "상설 전시"
   | "소장품 전시";
+
+export type SortType = "최신순" | "조회수순";


### PR DESCRIPTION
1. 전시회 목록 조회하는 api가 두가지로 나눠졌었는데 하나로 통일됨
    - 타입이 전체전시인지, 그외 영상전시, 그림전시 등인지에 따라 나뉘었는데 하나로 통일됨.
2. sort라는 파라미터가 api에 추가됨. 정렬이 최신순으로만 되었었는데 조회수순도 추가됨(인기순이었는데 변경됨)
    - 블로그리뷰/메이트글 작성에 사용되는 전시회 선택모달에도 전시회목록 조회 api 사용되어서 에러없게 수정함.


현재 수정은 다 완료되었는데 백엔드에 요청을 보내도 조회수순 정렬이 안돼서 그 부분은 다시 말씀드릴 예정입니다.