### PR TITLE
Fix: 메이트글 목록 조회 api 수정, 메이트글 목록 조회 실패시 메인페이지로 리다이렉트 기능 추가

### DIFF
--- a/src/apis/mate.tsx
+++ b/src/apis/mate.tsx
@@ -94,10 +94,10 @@ export interface BookMarkRes {
   data?: true | false;
 }
 
-// 메이트 목록 조회 api_박예선_23.01.26
+// 메이트 목록 조회 api_박예선_23.02.26
 export const mateListApi = async (status: MateStatusType, page: number) => {
   const res: AxiosResponse<MateListType> = await apiInstance.get(
-    `/mates?page=${page}&status=${status === "전체" ? "" : status}`
+    `/mates?page=${page}&status=${status}`
   );
   return res;
 };

--- a/src/pages/MateList.tsx
+++ b/src/pages/MateList.tsx
@@ -1,5 +1,6 @@
-import { AxiosResponse } from "axios";
 import React, { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { AxiosResponse } from "axios";
 import styled from "styled-components";
 import MateListFilter, {
   MateStatusType,
@@ -12,15 +13,16 @@ import { mateListApi } from "../apis/mate";
 import NoList from "../components/NoList";
 import { alertError } from "../utils/alerts";
 
-// 메이트글 목록 페이지_박예선_23.02.01
+// 메이트글 목록 페이지_박예선_23.02.26
 const MateList = () => {
+  const navigate = useNavigate();
   const [mateList, setMateList] = useState<Mate[] | null>(null);
   const [mateStatusFilter, setMateStatusFilter] =
     useState<MateStatusType>("전체");
   const [pages, setPages] = useState<PagesState>({ started: 1, selected: 1 });
   const [totalPage, setTotalPage] = useState(1);
 
-  // 메이트글 목록 조회 api 호출_박예선_23.01.26
+  // 메이트글 목록 조회 api 호출_박예선_23.02.26
   const getMateList = useCallback(
     async (status: MateStatusType, page: number) => {
       try {
@@ -33,9 +35,10 @@ const MateList = () => {
         setTotalPage(pageInfo.totalPage);
       } catch (err) {
         alertError();
+        navigate("/");
       }
     },
-    []
+    [navigate]
   );
 
   // 메이트글 목록 조회_박예선_23.02.01


### PR DESCRIPTION
1. 메이트글 목록 조회 api에서 '전체' 필터이면 값을 안넣는 구조였는데, 전체도 값을 넣는 구조로 변경되어 반영했습니다
2. 메이트글 목록 조회 실패 시 메인페이지로 리다이렉트 기능 추가했습니다

현재 백엔드 코드만 수정된 상태로 버그 발생중이니 빠른 확인 부탁드립니다.