### PR TITLE
Feat: withauth 고차 컴포넌트 작성

### DIFF
--- a/src/components/WithAuth.tsx
+++ b/src/components/WithAuth.tsx
@@ -1,0 +1,20 @@
+import React, { ComponentType } from "react";
+import { useNavigate } from "react-router-dom";
+
+export default function WithAuth(Component: ComponentType) {
+  const accessToken = localStorage.getItem("accessToken");
+
+  /* eslint-disable */
+  return function Auth<P extends {}>(props: P | undefined) {
+    const navigate = useNavigate();
+
+    React.useEffect(() => {
+      if (!accessToken) {
+        alert("로그인이 필요한 페이지입니다.");
+        navigate("/login");
+      }
+    });
+
+    return <Component {...props} />;
+  };
+}


### PR DESCRIPTION
 - 로그인해야 보이는 페이지에서 export default 부분을 WithAuth컴포넌트로 래핑해주면 accessToken 존재 여부를 확인하여 없으면 로그인 페이지로 리다이렉트하는 고차 컴포넌트입니다. 
 - 래핑할 경우 반대로 하위 컴포넌트의 권한 분기처리를 지워주셔야 합니다.
 - 로그인 여부 이외에 추가적인 권한 분기의 경우 WithAuth에서 처리할 지 하위 컴포넌트에서 다룰 지 상의가 필요할 것 같습니다.


