### PR TITLE
Fix: 전시회상세페이지 북마크 실패해도 아이콘 변경되는 오류 수정

### DIFF
--- a/src/apis/exhibition.tsx
+++ b/src/apis/exhibition.tsx
@@ -54,7 +54,7 @@ export const exhbDeleteApi = async (id: number) => {
 // 전시글 북마크
 export const exhbBookMarkApi = async (id: number) => {
   const res: AxiosResponse<BookMarkRes> = await apiInstance.put(
-    `/api/bookmarks/exhibitions/${id}`
+    `/api/exhibitions/bookmarks/${id}`
   );
   return res;
 };

--- a/src/components/atom/BookMark.tsx
+++ b/src/components/atom/BookMark.tsx
@@ -2,34 +2,57 @@ import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { ReactComponent as HeartOn } from "../../assets/icons/heartOn.svg";
 import { ReactComponent as HeartOff } from "../../assets/icons/heartOff.svg";
+import { exhbBookMarkApi } from "../../apis/exhibition";
+import useRefreshTokenApi from "../../apis/useRefreshToken";
+import isApiError from "../../utils/isApiError";
 
 interface BookMarkType {
-  onClick: () => void;
-  marked: boolean;
+  exhbId: number;
+  bookmarked: boolean;
 }
 
-const BookMark = ({ onClick, marked }: BookMarkType) => {
-  const [isChecked, setIsChecked] = useState(marked);
+const BookMark = ({ exhbId, bookmarked }: BookMarkType) => {
+  const refreshTokenApi = useRefreshTokenApi();
+  const [isChecked, setIsChecked] = useState(bookmarked);
   const [isMouseOver, setIsMouseOver] = useState(false);
 
   useEffect(() => {
-    setIsChecked(marked);
-  }, [marked]);
+    setIsChecked(bookmarked);
+  }, [bookmarked]);
 
-  const handleCheck = () => {
+  // 북마크 추가/해제
+  const handleBookMark = async () => {
     if (!localStorage.getItem("accessToken")) {
       alert("해당 기능은 로그인 후 이용 가능합니다.");
+      return;
     }
-    setIsChecked((prev) => !prev);
+    try {
+      const res = await exhbBookMarkApi(exhbId);
+      const { msg } = res.data;
+      alert(msg);
+      setIsChecked((prev) => !prev);
+    } catch (err) {
+      isApiError(err);
+      const errorRes = isApiError(err);
+      if (errorRes === "accessToken 만료") {
+        await refreshTokenApi();
+        const reRes = await exhbBookMarkApi(exhbId);
+        const { msg } = reRes.data;
+        alert(msg);
+        setIsChecked((prev) => !prev);
+      }
+      if (typeof errorRes !== "object") return;
+      const { errorCode, errorMsg } = errorRes;
+      if (errorCode === 404 && errorMsg === "회원 정보 없음") {
+        alert("유효하지 않은 토큰입니다. 다시 로그인해주세요.");
+      }
+    }
   };
 
   return (
     <BookMarkContainer
       type="button"
-      onClick={() => {
-        onClick();
-        handleCheck();
-      }}
+      onClick={handleBookMark}
       onMouseOver={() => setIsMouseOver(true)}
       onMouseOut={() => setIsMouseOver(false)}
     >

--- a/src/components/atom/BookMark.tsx
+++ b/src/components/atom/BookMark.tsx
@@ -8,17 +8,17 @@ import isApiError from "../../utils/isApiError";
 
 interface BookMarkType {
   exhbId: number;
-  bookmarked: boolean;
+  isBookmarked: boolean;
 }
 
-const BookMark = ({ exhbId, bookmarked }: BookMarkType) => {
+const BookMark = ({ exhbId, isBookmarked }: BookMarkType) => {
   const refreshTokenApi = useRefreshTokenApi();
-  const [isChecked, setIsChecked] = useState(bookmarked);
+  const [isChecked, setIsChecked] = useState(isBookmarked);
   const [isMouseOver, setIsMouseOver] = useState(false);
 
   useEffect(() => {
-    setIsChecked(bookmarked);
-  }, [bookmarked]);
+    setIsChecked(isBookmarked);
+  }, [isBookmarked]);
 
   // 북마크 추가/해제
   const handleBookMarkBtn = async () => {

--- a/src/components/atom/BookMark.tsx
+++ b/src/components/atom/BookMark.tsx
@@ -21,7 +21,7 @@ const BookMark = ({ exhbId, bookmarked }: BookMarkType) => {
   }, [bookmarked]);
 
   // 북마크 추가/해제
-  const handleBookMark = async () => {
+  const handleBookMarkBtn = async () => {
     if (!localStorage.getItem("accessToken")) {
       alert("해당 기능은 로그인 후 이용 가능합니다.");
       return;
@@ -52,7 +52,7 @@ const BookMark = ({ exhbId, bookmarked }: BookMarkType) => {
   return (
     <BookMarkContainer
       type="button"
-      onClick={handleBookMark}
+      onClick={handleBookMarkBtn}
       onMouseOver={() => setIsMouseOver(true)}
       onMouseOut={() => setIsMouseOver(false)}
     >

--- a/src/components/exhibition/MainCard.tsx
+++ b/src/components/exhibition/MainCard.tsx
@@ -146,7 +146,7 @@ const MainCard = ({
             </WebLink>
             {localStorage.getItem("authority") !== "ROLE_ADMIN" && (
               <BookMarkBtn>
-                <BookMark exhbId={id} bookmarked={bookmarked} />
+                <BookMark exhbId={id} isBookmarked={bookmarked} />
               </BookMarkBtn>
             )}
             <ShareBtn type="button" onClick={copyLink} />

--- a/src/components/exhibition/MainCard.tsx
+++ b/src/components/exhibition/MainCard.tsx
@@ -1,12 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { AxiosResponse } from "axios";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
-import {
-  BookMarkRes,
-  exhbBookMarkApi,
-  exhbDeleteApi,
-} from "../../apis/exhibition";
+import { exhbDeleteApi } from "../../apis/exhibition";
 import { theme } from "../../styles/theme";
 import isApiError from "../../utils/isApiError";
 import BookMark from "../atom/BookMark";
@@ -59,30 +54,6 @@ const MainCard = ({
         await exhbDeleteApi(id);
         alert("전시글 삭제가 완료되었습니다.");
         navigate("/exhibition-list");
-      }
-    }
-  };
-
-  // 북마크 버튼
-  const toggleBookMark = async () => {
-    if (!localStorage.getItem("accessToken")) return;
-    try {
-      const res: AxiosResponse<BookMarkRes> = await exhbBookMarkApi(id);
-      const { msg } = res.data;
-      alert(msg);
-    } catch (err) {
-      isApiError(err);
-      const errorRes = isApiError(err);
-      if (errorRes === "accessToken 만료") {
-        await refreshTokenApi();
-        const reRes = await exhbBookMarkApi(id);
-        const { msg } = reRes.data;
-        alert(msg);
-      }
-      if (typeof errorRes !== "object") return;
-      const { errorCode, errorMsg } = errorRes;
-      if (errorCode === 404 && errorMsg === "회원 정보 없음") {
-        alert("유효하지 않은 토큰입니다. 다시 로그인해주세요.");
       }
     }
   };
@@ -175,7 +146,7 @@ const MainCard = ({
             </WebLink>
             {localStorage.getItem("authority") !== "ROLE_ADMIN" && (
               <BookMarkBtn>
-                <BookMark onClick={toggleBookMark} marked={bookmarked} />
+                <BookMark exhbId={id} bookmarked={bookmarked} />
               </BookMarkBtn>
             )}
             <ShareBtn type="button" onClick={copyLink} />


### PR DESCRIPTION
1. 북마크를 클릭했을 때 발생하는 두가지의 함수가 각자 다른 파일에서 관리되고 있어 유지보수를 위해 북마크 파일에서 관리하도록 위치를 이동하고, 함수를 합쳤습니다. 
2. 북마크 여부를 부모 컴포넌트에서 북마크 컴포넌트로 넘겨주는데, 가독성과 유지보수를 위해 변수명을 marked-> bookmarked로 통일했습니다.
3. 기존 로직은 클릭했을 경우 토큰이 있든 없든/ 통신에 성공하든 실패하든 무조건 색상이 변경되는데 토큰이 없으면 로그인 알림이 뜨고 return을 하도록 하여 색상변경이 이루어지지 않도록 했습니다. 마찬가지로 통신에 실패해도 색상변경이 되지 않도록 성공시에만 setIsChecked((prev) => !prev);를 넣었습니다.
4. 동규님이 변경하셨는데 아직 반영이 안된 전시글 북마크 api 여기서도 변경했습니다. 테스트를 위해 변경했는데 아직 동규님 pr이 머지가 안되어서 제가 먼저 될 수도 있어서 이 pr에도 포함시켰습니다.