### PR TITLE
Design: 전시리뷰 목록 없을 시 NoList 컴포넌트 레이아웃 깨짐 수정

### DIFF
--- a/src/components/blogReviewList/ReviewCardList.tsx
+++ b/src/components/blogReviewList/ReviewCardList.tsx
@@ -6,21 +6,23 @@ import NoList from "../NoList";
 import ReviewCard from "./ReviewCard";
 
 const ReviewCardList = ({ blogInfo }: BlogReviewListRes) => (
-  <ReviewCardListContainer>
+  <>
     {blogInfo.length === 0 && <NoList notice="작성된 리뷰가 없습니다." />}
-    {blogInfo.length !== 0 &&
-      blogInfo.map((each) => (
-        <ReviewCard
-          key={each.id}
-          id={each.id}
-          title={each.title}
-          writer={each.writer}
-          viewDate={each.viewDate}
-          viewCount={each.viewCount}
-          imageInfo={each.imageInfo}
-        />
-      ))}
-  </ReviewCardListContainer>
+    <ReviewCardListContainer>
+      {blogInfo.length !== 0 &&
+        blogInfo.map((each) => (
+          <ReviewCard
+            key={each.id}
+            id={each.id}
+            title={each.title}
+            writer={each.writer}
+            viewDate={each.viewDate}
+            viewCount={each.viewCount}
+            imageInfo={each.imageInfo}
+          />
+        ))}
+    </ReviewCardListContainer>
+  </>
 );
 
 export default ReviewCardList;

--- a/src/pages/BlogReview.tsx
+++ b/src/pages/BlogReview.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { useQuery } from "react-query";
 import { useLocation } from "react-router-dom";
 import styled from "styled-components";
@@ -12,10 +12,6 @@ interface LocationState {
 
 const BlogReview = () => {
   const location: LocationState = useLocation();
-
-  useEffect(() => {
-    console.log(location);
-  }, [location]);
 
   const { isLoading, isError, error, data } = useQuery({
     queryKey: ["blogReviewDetail"],

--- a/src/pages/BlogReview.tsx
+++ b/src/pages/BlogReview.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useQuery } from "react-query";
 import { useLocation } from "react-router-dom";
 import styled from "styled-components";
@@ -12,6 +12,10 @@ interface LocationState {
 
 const BlogReview = () => {
   const location: LocationState = useLocation();
+
+  useEffect(() => {
+    console.log(location);
+  }, [location]);
 
   const { isLoading, isError, error, data } = useQuery({
     queryKey: ["blogReviewDetail"],


### PR DESCRIPTION
NoList 컴포넌트가 자식컴포넌트 넓이인 380px로 고정이 되어나와서 ReviewCardListContainer 컴포넌트 바깥으로 위치를 이동했습니다