### PR TITLE
Fix: exhibition 개별 페이지 searchBar 컴포넌트 수정

### DIFF
--- a/src/components/atom/Searchbar.tsx
+++ b/src/components/atom/Searchbar.tsx
@@ -1,8 +1,8 @@
-import React from "react";
+import React, { HTMLAttributes } from "react";
 import styled from "styled-components";
 import { theme } from "../../styles/theme";
 
-interface SearchbarProps {
+interface SearchbarProps extends HTMLAttributes<HTMLInputElement> {
   placeholder?: string;
   width: string;
 }

--- a/src/components/reviewCommon/ReviewSearchBar.tsx
+++ b/src/components/reviewCommon/ReviewSearchBar.tsx
@@ -57,9 +57,9 @@ const ReviewSearchBar = ({
           }}
         >
           <SearchBar
-            placeholder="검색기능은 현재 지원하지 않습니다."
+            placeholder="검색"
             width="277px"
-            disabled
+            onClick={() => alert("준비중인 기능입니다.")}
           />
         </form>
         <Button onClick={handleReviewModal} variant="primary" size="large">


### PR DESCRIPTION
- exhibition/${number}페이지에서 검색창에 보이는 플레이스 홀더 삭제
- 클릭 시 아직 지원하지 않는 기능 표시
- 백엔드에서 기능은 만들어주셨고 제가 구현하는데는 아직 시간이 약간 걸릴 것 같아 표시만 변경해뒀습니다..