### PR TITLE
Fix: 전시회 목록 조회 요청 실패 시 메인페이지로 리다이렉트

### DIFF
--- a/src/pages/ExhibitionList.tsx
+++ b/src/pages/ExhibitionList.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { AxiosResponse } from "axios";
 import styled from "styled-components";
 import { theme } from "../styles/theme";
@@ -10,6 +11,7 @@ import ExhbCardList from "../components/exhibitionList/ExhbCardList";
 
 // 전시회 목록 페이지 컴포넌트_박예선_23.02.24
 const ExhibitionList = () => {
+  const navigate = useNavigate();
   const [exhbList, setExhbList] = useState<Exhibition[]>([]);
   const [totalPage, setTotalPage] = useState<number>(0);
   const [selectedStatus, setSelectedStatus] = useState<StatusType>("현재");
@@ -22,7 +24,7 @@ const ExhibitionList = () => {
     selected: 1,
   });
 
-  // 전시회 목록 요청 api_박예선_23.01.24
+  // 전시회 목록 조회 api_박예선_23.03.01
   const getExhbList = useCallback(
     async (
       status: StatusType,
@@ -44,9 +46,10 @@ const ExhibitionList = () => {
         alert(
           "죄송합니다.\n전시목록을 불러오는데에 실패하였습니다. 다시 시도해주십시오."
         );
+        navigate("/");
       }
     },
-    []
+    [navigate]
   );
 
   // 전시상태, 전시유형 필터, 페이지 번호에 따라 전시목록 불러오는 로직_박예선_23.02.24


### PR DESCRIPTION
- 전시회 목록 조회에 실패했을 시 그대로 전시회 목록 페이지에 위치함으로서 사용자에게 잘못된 정보를 보여주는 것보단 메인페이지로 이동하는 게 좋을 것 같아서 추가했습니다.