### PR TITLE
Fix: 전시리뷰 작성페이지 날짜 두번 클릭해야 선택되는 오류 수정

### DIFF
--- a/src/pages/BlogReviewModify.tsx
+++ b/src/pages/BlogReviewModify.tsx
@@ -329,6 +329,9 @@ const BlogReviewUpdate = () => {
             <Calender
               selectedDate={pathDate}
               handleSelectedDate={setSelectedDate}
+              // selectedDate={new Date(작성 시 선택한 날짜)}
+              // 수정페이지일 때도 마찬가지로 '작성 시 선택한 날짜'를 넘겨줘야 할텐데,
+              // 현재 수정모드일 때 기존에 선택된 날짜를 어떻게 받아오고 계신지 모르겠어서 일단 주석만 남겨둡니다.-예선
             />
           </div>
         </ExhibitionPicker>

--- a/src/pages/BlogReviewWrite.tsx
+++ b/src/pages/BlogReviewWrite.tsx
@@ -1,7 +1,8 @@
-import React, { useState, ChangeEvent, useReducer, useEffect } from "react";
+import React, { useState, ChangeEvent } from "react";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { useMutation } from "react-query";
-import { useLocation, useNavigate } from "react-router-dom";
+import { format } from "date-fns";
 import ReviewTitle from "../components/blogreview/ReviewTitle";
 import ExhibitionSelect from "../components/blogreview/ExhibitionSelect";
 import Calender from "../components/Calendar";
@@ -143,7 +144,9 @@ import useRefreshTokenApi from "../apis/useRefreshToken";
 const BlogReviewWrite = () => {
   // const [state, dispatch] = useReducer(reducer, initialState);
   const [title, setTitle] = useState("");
-  const [selectedDate, setSelectedDate] = useState("");
+  const [selectedDate, setSelectedDate] = useState(
+    format(new Date(), "yyyy-mm-dd")
+  );
   const [enterTime, setEnterTime] = useState("");
   const [exitTime, setExitTime] = useState("");
   const [congestion, setCongestion] = useState("");
@@ -330,9 +333,12 @@ const BlogReviewWrite = () => {
           <div>
             <SubTitle text="관람일" />
             <Calender
-              selectedDate={new Date()}
+              selectedDate={new Date(selectedDate)}
               handleSelectedDate={setSelectedDate}
             />
+            {/* 왜 이렇게 들어가야 하는지 헷갈리시면 
+            메이트글 작성/수정 페이지 컴포넌트인
+            src-pages-MateWrite.tsx 파일 참고부탁드립니다 - 예선 */}
           </div>
         </ExhibitionPicker>
         <SelectorConatiner>


### PR DESCRIPTION
1. 전시리뷰 작성 컴포넌트(BlogReviewWrite)
    - selectedDate 상태 초기값을 "" => format(new Date(), "yyyy-mm-dd")로 수정
    - 캘린더 컴포넌트에 전달해주는 값을 new Date() => new Date(selectedDate)로 수정
    - 날짜를 클릭하면 바로 selectedDate가 업데이트 되기 때문에 이제 한번만 클릭해도 바로 날짜 정상반영됩니다!
    - 작성 후 블로그리뷰 상세페이지에서 선택된 날짜 정상 표시 되는 부분 확인했습니다.
    - ‼️다만 수정페이지 들어가면 아직 오늘 날짜로 보여서 동규님이 수정해주셔야 합니다!

2. 전시리뷰 수정 컴포넌트(BlogReviewModify)
    - ‼️현재 어떤 방식으로 작성 시 선택된 날짜를 받아오고 있는지 모르겠어서 일단 주석 추가해두었습니다. 동규님께서 확인하시고 수정해주시면 될 것 같아요
    - ‼️전시 리뷰 수정 시 기존에 작성했던 제목이 안보이는 오류가 추가로 있습니다. 그것도 수정하셔야 할 것 같네요

3. 사용하지 않는 import 삭제

동규님 승인 후 머지하겠습니당