### PR TITLE
Feat: 이미지 우클릭 방지 기능 추가

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
     />
     <title>MyAlley - 전시회 정보와 메이트 찾기</title>
   </head>
-  <body>
+  <body oncontextmenu="return false;">
     <div id="root"></div>
     <div id="portal"></div>
   </body>


### PR DESCRIPTION
전시회 포스터 이미지가 무분별하게 저장되는 것을 막기 위해 body 태그에 우클릭 방지 속성을 추가해주었습니다.
처음에는 이미지 하나하나에 속성을 적용하려고 했으나 
body 태그가 아닌 다른 태그에서는 동작을 하지 않아 body 태그에 속성을 추가했습니다.