### PR TITLE
Fix: 비 로그인시 블로그 리뷰 상세표시와 css 정렬수정

### DIFF
--- a/src/apis/blogReviewApis.tsx
+++ b/src/apis/blogReviewApis.tsx
@@ -26,7 +26,7 @@ const blogReviewApis = {
     const response: AxiosResponse<BlogReviewDetailResponse> =
       await apiInstance.get(`/blogs/${blogId}`, {
         headers: {
-          memberId: localStorage.getItem("memberId"),
+          memberId: localStorage.getItem("memberId") ?? 0,
         },
       });
     return response.data;

--- a/src/components/blogReviewList/ReviewCard.tsx
+++ b/src/components/blogReviewList/ReviewCard.tsx
@@ -87,9 +87,13 @@ const ThumbnailContainer = styled.div`
 const Content = styled.div`
   height: 38%;
   padding: 30px;
+  text-align: left;
   h2 {
     margin-bottom: 4px;
     color: ${theme.colors.greys90};
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
     font-weight: bold;
     font-size: 20px;
     line-height: 28px;

--- a/src/components/blogreview/container/BlogReviewReadContainer.tsx
+++ b/src/components/blogreview/container/BlogReviewReadContainer.tsx
@@ -109,6 +109,7 @@ const CardWrapper = styled.div`
   grid-template-columns: repeat(3, 380px);
   grid-template-rows: auto;
   gap: 30px;
+  text-align: left;
   margin-bottom: 30px;
 `;
 

--- a/src/components/onelineReview/presentation/MypageOnelineCard.tsx
+++ b/src/components/onelineReview/presentation/MypageOnelineCard.tsx
@@ -57,9 +57,7 @@ const MypageOnelineCard = ({
           <div className="exhibition-title">{exhibitionInfo?.title}</div>
           {/* eslint-disable */}
           {[...Array(rate)].map((_, index) => (
-            <div key={`star-rate-${index}`}>
-              <img src={StarIcon} alt="별점" />
-            </div>
+            <img key={`star-rate-${index}`} src={StarIcon} alt="별점" />
           ))}
           <DateInfo>
             <span>{viewDate}</span> | <span>{time}</span> |{" "}


### PR DESCRIPTION
1. 로그인 안 한 상태에서 블로그 리뷰 클릭 시 상세페이지 정보가 표시되도록 수정
2. 전시회 상세페이지의 블로그 리뷰 목록에서 제목과 닉네임 왼쪽 정렬
3. 블로그 리뷰 글의 제목이 너무 긴 경우 하단의 정보들이 다같이... 표시로 전환
4. '마이페이지-작성글 조회-한줄리뷰' 에서 별점의 별을 가로정렬