### PR TITLE
Fix: 전시글목록 api 수정사항 반영(전시회 제목 검색 title 파라미터 추가, sort/type파라미터 기본값 ""으로 수정"

### DIFF
--- a/src/apis/exhbList.tsx
+++ b/src/apis/exhbList.tsx
@@ -23,7 +23,7 @@ const exhbListApi = async (
   const res: AxiosResponse<ExhbListRes> = await apiInstance.get(
     `/exhibitions/?status=${status} 전시&page=${page}&sort=${
       sort === "최신순" ? "" : "조회수순"
-    }&type=${type}&title=""` // title(검색)은 임시로 ""로 보냄
+    }&type=${type === "전체 전시" ? "" : type}&title=""` // title(검색)은 임시로 ""로 보냄
   );
   return res;
 };

--- a/src/apis/exhbList.tsx
+++ b/src/apis/exhbList.tsx
@@ -25,4 +25,17 @@ const exhbListApi = async (
   return res;
 };
 
+const searchedExhbListApi = async (
+  status: StatusType,
+  type: FilterType,
+  sort: SortType,
+  title: string,
+  page: number
+) => {
+  const res: AxiosResponse<ExhbListRes> = await apiInstance.get(
+    `/exhibitions/search?status=${status}&title=${title}&page=${page}`
+  );
+  return res;
+};
+
 export default exhbListApi;

--- a/src/apis/exhbList.tsx
+++ b/src/apis/exhbList.tsx
@@ -18,22 +18,12 @@ const exhbListApi = async (
   type: FilterType,
   sort: SortType,
   page: number
+  // title:string 추후 검색 기능 추가 시 활성화할 예정
 ) => {
   const res: AxiosResponse<ExhbListRes> = await apiInstance.get(
-    `/exhibitions/?status=${status} 전시&type=${type}&sort=${sort}&page=${page}`
-  );
-  return res;
-};
-
-const searchedExhbListApi = async (
-  status: StatusType,
-  type: FilterType,
-  sort: SortType,
-  title: string,
-  page: number
-) => {
-  const res: AxiosResponse<ExhbListRes> = await apiInstance.get(
-    `/exhibitions/search?status=${status}&title=${title}&page=${page}`
+    `/exhibitions/?status=${status} 전시&page=${page}&sort=${
+      sort === "최신순" ? "" : "조회수순"
+    }&type=${type}&title=""` // title(검색)은 임시로 ""로 보냄
   );
   return res;
 };

--- a/src/components/ExhibitionChoice.tsx
+++ b/src/components/ExhibitionChoice.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import { useQuery } from "react-query";
-import exhbListApi, { ExhbListRes } from "../apis/getExhbList";
+import exhbListApi, { ExhbListRes } from "../apis/exhbList";
 import { theme } from "../styles/theme";
 import ExhbCardListModal from "./exhbChoiceModal/ExhbCardListModal";
 import Button from "./atom/Button";

--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -73,7 +73,7 @@ const Filters = (props: FiltersType) => {
           />
         </div>
         <SearchInput
-          placeholder="검색"
+          placeholder="전시회 제목으로 찾기"
           onClick={() => alert("준비 중인 기능입니다.")}
           onKeyDown={(e) => {
             if (e.key === "Enter") alertPreparing();

--- a/src/pages/ExhibitionList.tsx
+++ b/src/pages/ExhibitionList.tsx
@@ -4,7 +4,7 @@ import { AxiosResponse } from "axios";
 import styled from "styled-components";
 import { theme } from "../styles/theme";
 import { Exhibition, FilterType, SortType } from "../types/exhbList";
-import exhbListApi, { ExhbListRes } from "../apis/getExhbList";
+import exhbListApi, { ExhbListRes } from "../apis/exhbList";
 import Pagination from "../components/Pagination";
 import Filters, { StatusType } from "../components/exhibitionList/Filters";
 import ExhbCardList from "../components/exhibitionList/ExhbCardList";


### PR DESCRIPTION
1. 전시글 검색기능을 구현하며 기존 전시글 목록조회와 전시글 목록 검색 조회가 나눠져있던 게 합쳐져서 title파라미터를 추가했습니다.
2. 백엔드의 요청으로 sort "최신순"이면 ""으로, type "전체 전시"면 ""로 파라미터 값을 수정했습니다.
3. 전시글 목록 api 파일명 다른 api 파일명들과 통일감 있게 수정했습니다.
4. 전시글 목록 검색창 placeholder 전체 다수결 투표한 결과 반영했습니다.