### PR TITLE
HOTFIX: 전시회 목록, 메이트글 목록 조회 api 응답형식 변경(totalPage 부분) 미반영으로 인한 오류 수정

### DIFF
--- a/src/apis/exhbList.tsx
+++ b/src/apis/exhbList.tsx
@@ -5,14 +5,10 @@ import apiInstance from "../utils/apiInstance";
 
 export interface ExhbListRes {
   exhibitions: Exhibition[];
-  pageInfo: {
-    page: number;
-    size: number;
-    totalElement: number;
-    totalPage: number;
-  };
+  totalPage: number;
 }
 
+// 전시목록 조회 api(상태, 정렬, 필터, 제목검색, 페이지)_박예선_23.03.17
 const exhbListApi = async (
   status: StatusType,
   type: FilterType,
@@ -23,7 +19,7 @@ const exhbListApi = async (
   const res: AxiosResponse<ExhbListRes> = await apiInstance.get(
     `/exhibitions/?status=${status} 전시&page=${page}&sort=${
       sort === "최신순" ? "" : "조회수순"
-    }&type=${type === "전체 전시" ? "" : type}&title=""` // title(검색)은 임시로 ""로 보냄
+    }&type=${type === "전체 전시" ? "" : type}&title=` // title(검색)은 임시로 ""로 보냄
   );
   return res;
 };

--- a/src/components/ExhibitionChoice.tsx
+++ b/src/components/ExhibitionChoice.tsx
@@ -63,7 +63,7 @@ const ExhibitionChoice = ({ getExhbInfo, handleModal }: ChoiceProps) => {
           getExhbInfo={getExhbInfo}
           pages={pages}
           setPages={setPages}
-          totalPage={data.pageInfo.totalPage ?? 0}
+          totalPage={data.totalPage ?? 0}
         />
       )}
     </Container>

--- a/src/pages/ExhibitionList.tsx
+++ b/src/pages/ExhibitionList.tsx
@@ -24,7 +24,7 @@ const ExhibitionList = () => {
     selected: 1,
   });
 
-  // 전시회 목록 조회 api_박예선_23.03.01
+  // 전시회 목록 조회 api_박예선_23.03.17
   const getExhbList = useCallback(
     async (
       status: StatusType,
@@ -39,9 +39,9 @@ const ExhibitionList = () => {
           sort,
           page
         );
-        const { exhibitions, pageInfo } = res.data;
+        const { exhibitions } = res.data;
         setExhbList(exhibitions);
-        setTotalPage(pageInfo.totalPage);
+        setTotalPage(res.data.totalPage);
       } catch (err) {
         alert(
           "죄송합니다.\n전시목록을 불러오는데에 실패하였습니다. 다시 시도해주십시오."

--- a/src/pages/MateList.tsx
+++ b/src/pages/MateList.tsx
@@ -30,9 +30,9 @@ const MateList = () => {
           status,
           page
         );
-        const { mates, pageInfo } = res.data;
+        const { mates } = res.data;
         setMateList(mates);
-        setTotalPage(pageInfo.totalPage);
+        setTotalPage(res.data.totalPage);
       } catch (err) {
         alertError();
         navigate("/");

--- a/src/types/mateList.d.ts
+++ b/src/types/mateList.d.ts
@@ -1,5 +1,3 @@
-import { PageInfo } from "./pageInfo";
-
 export interface Mate {
   mateId: number;
   title: string;
@@ -21,5 +19,5 @@ export interface Mate {
 
 export interface MateListType {
   mates: Mate[];
-  pageInfo: PageInfo;
+  totalPage: number;
 }


### PR DESCRIPTION
- 전시회 목록, 메이트글 목록 조회 api를 변경할 때 총 페이지 수 부분 응답형식도 변경됐는데 그 부분을 제가 반영하지 않고 머지를 해서 오류가 생겼었습니다. 수정완료했습니다~