### PR TITLE
Fix: 메이트글 목록조회api 수정사항 반영

### DIFF
--- a/src/apis/mate.tsx
+++ b/src/apis/mate.tsx
@@ -97,7 +97,7 @@ export interface BookMarkRes {
 // 메이트 목록 조회 api_박예선_23.02.26
 export const mateListApi = async (status: MateStatusType, page: number) => {
   const res: AxiosResponse<MateListType> = await apiInstance.get(
-    `/mates?page=${page}&status=${status}`
+    `/mates?page=${page}&status=${status === "전체" ? "" : status}&title=` // 검색기능 추가안되어서 임시로 공백으로 보냄
   );
   return res;
 };


### PR DESCRIPTION
- 모집상태 '전체'일 경우 공백으로 보냄
- 검색키워드 title 파라미터 추가(아직 검색기능이 추가되진 않아서 공백으로 보내고 있습니다. 기능은 정상작동합니다!)