### PR TITLE
Feat: 전시회목록 전시제목으로 검색하는 기능 추가

### DIFF
--- a/src/apis/exhbList.tsx
+++ b/src/apis/exhbList.tsx
@@ -23,7 +23,7 @@ const exhbListApi = async (
   const res: AxiosResponse<ExhbListRes> = await apiInstance.get(
     `/exhibitions/?status=${status} 전시&page=${page}&sort=${
       sort === "최신순" ? "" : "조회수순"
-    }&type=${type}&title=""` // title(검색)은 임시로 ""로 보냄
+    }&type=${type === "전체 전시" ? "" : type}&title=""` // title(검색)은 임시로 ""로 보냄
   );
   return res;
 };

--- a/src/apis/exhbList.tsx
+++ b/src/apis/exhbList.tsx
@@ -25,4 +25,17 @@ const exhbListApi = async (
   return res;
 };
 
+const searchedExhbListApi = async (
+  status: StatusType,
+  type: FilterType,
+  sort: SortType,
+  title: string,
+  page: number
+) => {
+  const res: AxiosResponse<ExhbListRes> = await apiInstance.get(
+    `/exhibitions/search?status=${status}&title=${title}&page=${page}`
+  );
+  return res;
+};
+
 export default exhbListApi;

--- a/src/apis/exhbList.tsx
+++ b/src/apis/exhbList.tsx
@@ -18,22 +18,12 @@ const exhbListApi = async (
   type: FilterType,
   sort: SortType,
   page: number
+  // title:string 추후 검색 기능 추가 시 활성화할 예정
 ) => {
   const res: AxiosResponse<ExhbListRes> = await apiInstance.get(
-    `/exhibitions/?status=${status} 전시&type=${type}&sort=${sort}&page=${page}`
-  );
-  return res;
-};
-
-const searchedExhbListApi = async (
-  status: StatusType,
-  type: FilterType,
-  sort: SortType,
-  title: string,
-  page: number
-) => {
-  const res: AxiosResponse<ExhbListRes> = await apiInstance.get(
-    `/exhibitions/search?status=${status}&title=${title}&page=${page}`
+    `/exhibitions/?status=${status} 전시&page=${page}&sort=${
+      sort === "최신순" ? "" : "조회수순"
+    }&type=${type}&title=""` // title(검색)은 임시로 ""로 보냄
   );
   return res;
 };

--- a/src/apis/exhbList.tsx
+++ b/src/apis/exhbList.tsx
@@ -8,18 +8,18 @@ export interface ExhbListRes {
   totalPage: number;
 }
 
-// 전시목록 조회 api(상태, 정렬, 필터, 제목검색, 페이지)_박예선_23.03.17
+// 전시목록 조회 api(상태, 필터, 정렬, 페이지, 검색어(제목))_박예선_23.03.30
 const exhbListApi = async (
   status: StatusType,
   type: FilterType,
   sort: SortType,
-  page: number
-  // title:string 추후 검색 기능 추가 시 활성화할 예정
+  page: number,
+  title: string
 ) => {
   const res: AxiosResponse<ExhbListRes> = await apiInstance.get(
     `/exhibitions/?status=${status} 전시&page=${page}&sort=${
       sort === "최신순" ? "" : "조회수순"
-    }&type=${type === "전체 전시" ? "" : type}&title=` // title(검색)은 임시로 ""로 보냄
+    }&type=${type === "전체 전시" ? "" : type}&title=${title}`
   );
   return res;
 };

--- a/src/components/ExhibitionChoice.tsx
+++ b/src/components/ExhibitionChoice.tsx
@@ -28,7 +28,7 @@ const ExhibitionChoice = ({ getExhbInfo, handleModal }: ChoiceProps) => {
   const { data } = useQuery<ExhbListRes, Error>({
     queryKey: ["exhbList", { pages, exhbStatus }],
     queryFn: () =>
-      exhbListApi(exhbStatus, "전체 전시", "최신순", pages.selected).then(
+      exhbListApi(exhbStatus, "전체 전시", "최신순", pages.selected, "").then(
         (res) => res.data
       ),
   });

--- a/src/components/ExhibitionChoice.tsx
+++ b/src/components/ExhibitionChoice.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import { useQuery } from "react-query";
-import exhbListApi, { ExhbListRes } from "../apis/getExhbList";
+import exhbListApi, { ExhbListRes } from "../apis/exhbList";
 import { theme } from "../styles/theme";
 import ExhbCardListModal from "./exhbChoiceModal/ExhbCardListModal";
 import Button from "./atom/Button";

--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -1,14 +1,13 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import { theme } from "../../styles/theme";
 import Button from "../atom/Button";
 import SearchInput from "../atom/SearchInput";
 import Selectbox from "../atom/Selectbox";
 import { PagesState } from "../Pagination";
-import { alertPreparing } from "../../utils/alerts";
 import { FilterType, SortType } from "../../types/exhbList";
 
-// 전시글 목록 상단 필터 컴포넌트_박예선_23.02.26
+// 전시글 목록 상단 필터 컴포넌트_박예선_23.03.30
 const Filters = (props: FiltersType) => {
   const {
     setPages,
@@ -17,6 +16,7 @@ const Filters = (props: FiltersType) => {
     selectedFilter,
     setSelectedFilter,
   } = props;
+  const [searchInput, setSearchInput] = useState(selectedFilter.title);
 
   // 전시상황 버튼 클릭 함수_박예선_23.02.01
   const handleStatusBtn = (status: StatusType) => {
@@ -38,6 +38,16 @@ const Filters = (props: FiltersType) => {
         setSelectedFilter({ ...selectedFilter, type: value });
       }
     }
+  };
+
+  // 전시회 검색창 상태관리 함수_박예선_23.03.30
+  const handleSearchInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchInput(e.target.value);
+  };
+
+  // 검색창 입력어 제출(검색) 함수_박예선_23.03.30
+  const submitSearchInput = () => {
+    setSelectedFilter({ ...selectedFilter, title: searchInput });
   };
 
   return (
@@ -74,9 +84,10 @@ const Filters = (props: FiltersType) => {
         </div>
         <SearchInput
           placeholder="전시회 제목으로 찾기"
-          onClick={() => alert("준비 중인 기능입니다.")}
+          value={searchInput}
+          onChange={handleSearchInput}
           onKeyDown={(e) => {
-            if (e.key === "Enter") alertPreparing();
+            if (e.key === "Enter") submitSearchInput();
           }}
         />
       </div>
@@ -108,11 +119,13 @@ interface FiltersType {
   selectedFilter: {
     type: FilterType;
     sort: SortType;
+    title: string;
   };
   setSelectedFilter: React.Dispatch<
     React.SetStateAction<{
       type: FilterType;
       sort: SortType;
+      title: string;
     }>
   >;
 }

--- a/src/components/exhibitionList/Filters.tsx
+++ b/src/components/exhibitionList/Filters.tsx
@@ -73,7 +73,7 @@ const Filters = (props: FiltersType) => {
           />
         </div>
         <SearchInput
-          placeholder="검색"
+          placeholder="전시회 제목으로 찾기"
           onClick={() => alert("준비 중인 기능입니다.")}
           onKeyDown={(e) => {
             if (e.key === "Enter") alertPreparing();

--- a/src/pages/ExhibitionList.tsx
+++ b/src/pages/ExhibitionList.tsx
@@ -4,7 +4,7 @@ import { AxiosResponse } from "axios";
 import styled from "styled-components";
 import { theme } from "../styles/theme";
 import { Exhibition, FilterType, SortType } from "../types/exhbList";
-import exhbListApi, { ExhbListRes } from "../apis/getExhbList";
+import exhbListApi, { ExhbListRes } from "../apis/exhbList";
 import Pagination from "../components/Pagination";
 import Filters, { StatusType } from "../components/exhibitionList/Filters";
 import ExhbCardList from "../components/exhibitionList/ExhbCardList";

--- a/src/pages/ExhibitionList.tsx
+++ b/src/pages/ExhibitionList.tsx
@@ -9,7 +9,7 @@ import Pagination from "../components/Pagination";
 import Filters, { StatusType } from "../components/exhibitionList/Filters";
 import ExhbCardList from "../components/exhibitionList/ExhbCardList";
 
-// 전시회 목록 페이지 컴포넌트_박예선_23.02.24
+// 전시회 목록 페이지 컴포넌트_박예선_23.03.30
 const ExhibitionList = () => {
   const navigate = useNavigate();
   const [exhbList, setExhbList] = useState<Exhibition[]>([]);
@@ -18,26 +18,29 @@ const ExhibitionList = () => {
   const [selectedFilter, setSelectedFilter] = useState<{
     type: FilterType;
     sort: SortType;
-  }>({ type: "전체 전시", sort: "최신순" });
+    title: string;
+  }>({ type: "전체 전시", sort: "최신순", title: "" });
   const [pages, setPages] = useState({
     started: 1,
     selected: 1,
   });
 
-  // 전시회 목록 조회 api_박예선_23.03.17
+  // 전시회 목록 조회 api_박예선_23.03.30
   const getExhbList = useCallback(
     async (
       status: StatusType,
       type: FilterType,
       sort: SortType,
-      page: number
+      page: number,
+      title: string
     ) => {
       try {
         const res: AxiosResponse<ExhbListRes> = await exhbListApi(
           status,
           type,
           sort,
-          page
+          page,
+          title
         );
         const { exhibitions } = res.data;
         setExhbList(exhibitions);
@@ -52,13 +55,14 @@ const ExhibitionList = () => {
     [navigate]
   );
 
-  // 전시상태, 전시유형 필터, 페이지 번호에 따라 전시목록 불러오는 로직_박예선_23.02.24
+  // 전시상태, 전시유형 필터, 페이지 번호에 따라 전시목록 불러오는 로직_박예선_23.03.30
   useEffect(() => {
     getExhbList(
       selectedStatus,
       selectedFilter.type,
       selectedFilter.sort,
-      pages.selected
+      pages.selected,
+      selectedFilter.title
     );
   }, [getExhbList, selectedStatus, selectedFilter, pages.selected]);
 


### PR DESCRIPTION
- 전시회 목록 검색창에 제목을 기준으로 검색이 가능해졌습니다.
- ExhibitionChoice 컴포넌트(블로그 작성과 메이트글 작성 시 사용되는)에는 검색창이 없기 때문에 api 요청시 default로 ""을 넘겨주도록 했습니다. 정상작동확인했습니다


+++++))) 원래 검색을 실시하면 검색창 옆에 보라색 초기화 버튼을 누르는 방향으로 구현하기로 했는데,
조금 작업이 더 걸릴 것 같아서 일단 검색기능만 추가했습니다. 현재는 새로고침을 해야만 초기화가 가능합니다